### PR TITLE
Add structured GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,137 @@
+name: Bug report
+description: Report reproducible incorrect behavior in pwhois.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve pwhois. Search the existing issues before
+        reporting a problem, and use synthetic or sanitized data in this form.
+
+        Do not paste credentials, private application logs, or complete registry
+        responses containing personal or operational information. Report a
+        security vulnerability through the private security link in the issue
+        chooser instead of opening a public issue.
+
+  - type: input
+    id: pwhois-version
+    attributes:
+      label: pwhois version
+      description: Provide the exact module version, tag, or commit.
+      placeholder: v1.0.0 or commit e142b69
+    validations:
+      required: true
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      description: Paste the output of `go version`.
+      placeholder: go version go1.x.y darwin/arm64
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system
+      description: Include the operating system and architecture.
+      placeholder: macOS 15 arm64, Ubuntu 24.04 amd64, or Windows 11 amd64
+    validations:
+      required: true
+
+  - type: dropdown
+    id: lookup-type
+    attributes:
+      label: Lookup type
+      description: Select the public API or protocol operation involved.
+      options:
+        - IP lookup
+        - Routeview lookup
+        - Registry lookup
+        - Netblock lookup
+        - Connection setup
+        - Query formatting
+        - Response parsing or JSON output
+        - Not lookup-specific
+    validations:
+      required: true
+
+  - type: input
+    id: server
+    attributes:
+      label: WHOIS/PWHOIS server
+      description: Name the configured server, or state that a local test server was used.
+      placeholder: whois.pwhois.org or local synthetic test server
+    validations:
+      required: true
+
+  - type: dropdown
+    id: network-path
+    attributes:
+      label: Test path
+      description: Tell us whether the reproduction contacts a public service.
+      options:
+        - Deterministic local test with no public network access
+        - Live public-server integration test
+        - Both local and live tests
+        - Not network-related
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest complete Go program or test that demonstrates the problem.
+      render: go
+    validations:
+      required: true
+
+  - type: textarea
+    id: inputs
+    attributes:
+      label: Sanitized inputs
+      description: List the IP addresses, ASN values, configuration, or synthetic response needed to reproduce the problem. Remove private data.
+      placeholder: |
+        Server configuration:
+        Lookup input:
+        Synthetic response, if applicable:
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Explain the result or error you expected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the complete error chain or panic, but remove private and unrelated data.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add sanitized logs, timing details, or links to related issues. Do not include a complete live registry response.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched the open and closed issues for this problem.
+          required: true
+        - label: I removed credentials, private logs, and personal or operational registry data.
+          required: true
+        - label: I understand that required CI tests must not depend on a public WHOIS/PWHOIS service.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Go package documentation
+    url: https://pkg.go.dev/github.com/georgestarcher/pwhois
+    about: Review the public API, exported types, and package documentation.
+  - name: Security vulnerability
+    url: https://github.com/georgestarcher/pwhois/security/advisories/new
+    about: Report security problems privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,65 @@
+name: Documentation issue
+description: Report missing, unclear, or incorrect pwhois documentation.
+title: "Docs: "
+labels:
+  - documentation
+body:
+  - type: dropdown
+    id: location
+    attributes:
+      label: Documentation location
+      options:
+        - README
+        - Go package documentation on pkg.go.dev
+        - Exported type, function, or method comment
+        - Code example
+        - Integration-test instructions
+        - Release or migration documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: link-or-symbol
+    attributes:
+      label: Link, file, or exported symbol
+      description: Identify the exact documentation or API being discussed.
+      placeholder: README.md Usage, WhoisServer.Connect, or a pkg.go.dev URL
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is unclear or incorrect?
+      description: Quote only the minimum text needed and explain why it is misleading, incomplete, or stale.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Suggested improvement
+      description: Describe the wording, example, or structure that would resolve the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: user-goal
+    attributes:
+      label: Reader goal
+      description: What was the reader trying to accomplish when the documentation failed them?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I checked the current README and pkg.go.dev documentation.
+          required: true
+        - label: Any example data is synthetic and contains no private registry information.
+          required: true
+        - label: I searched the open and closed issues for this documentation problem.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,96 @@
+name: Feature request
+description: Propose a focused improvement to the reusable pwhois Go module.
+title: "Feature: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the consumer problem first. pwhois is a reusable Go library for
+        bounded WHOIS/PWHOIS lookups; application-specific storage, scheduling,
+        dashboards, and credential management normally belong in consuming code.
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Consumer use case
+      description: What does application code need to accomplish, and why are the existing APIs insufficient?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: lookup-types
+    attributes:
+      label: Affected lookup types
+      description: Select every operation this proposal affects.
+      multiple: true
+      options:
+        - IP lookup
+        - Routeview lookup
+        - Registry lookup
+        - Netblock lookup
+        - Shared connection or transport behavior
+        - Query formatting or validation
+        - Response parsing or JSON output
+        - Documentation or tooling only
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or behavior
+      description: Describe the public behavior and include a small Go usage example when possible.
+      render: go
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include caller-owned solutions and composition with standard-library interfaces.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: compatibility
+    attributes:
+      label: Compatibility impact
+      options:
+        - Additive public API
+        - Behavioral change to an existing API
+        - Breaking public API or JSON change
+        - Documentation, tests, or tooling only
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: network-resource-impact
+    attributes:
+      label: Network and resource impact
+      description: Explain new connections, servers, data disclosure, retries, limits, timeouts, memory use, or concurrency behavior. Write "None" if this is not applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: testing
+    attributes:
+      label: Suggested deterministic validation
+      description: Explain how this can be tested without relying on a public service.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope confirmation
+      options:
+        - label: This belongs in a reusable WHOIS/PWHOIS Go module rather than only in a consuming application.
+          required: true
+        - label: The proposal keeps public network tests optional and required CI deterministic.
+          required: true
+        - label: I searched the open and closed issues for an existing proposal.
+          required: true


### PR DESCRIPTION
## Summary

Add repository-specific GitHub issue forms for actionable bug, feature, and documentation reports.

## What changed

- add a bug form requiring the exact module, Go, OS, lookup, server, reproduction, and sanitized input context
- add a focused feature form covering API compatibility, network/resource impact, alternatives, and deterministic validation
- add a documentation form for README, pkg.go.dev, examples, integration guidance, and release documentation
- disable blank issues and route package questions to pkg.go.dev and vulnerabilities to private security advisories

## Why

Structured forms reduce back-and-forth, keep required CI independent of public WHOIS services, and discourage credentials or live registry data from entering public issues.

This partially addresses #27. The remaining community-health and maintainer files stay in that issue.

## Validation

- parsed every YAML file successfully
- checked required top-level fields, unique field IDs, supported form element types, and unique dropdown options
- confirmed the referenced `bug`, `enhancement`, and `documentation` labels exist
- `git diff --check`
- `go test ./... -timeout 30s`