### PR TITLE
Harden PWHOIS parsing and refresh documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
-# pwhois [![Go Reference](https://pkg.go.dev/badge/github.com/georgestarcher/pwhois.svg)](https://pkg.go.dev/github.com/georgestarcher/pwhois) [![Report Card](https://goreportcard.com/badge/github.com/georgestarcher/pwhois)](https://goreportcard.com/report/github.com/georgestarcher/pwhois) [![Build Status](https://github.com/georgestarcher/pwhois/workflows/pwhois%20CI/badge.svg)](https://github.com/georgestarcher/pwhois/actions)
+# pwhois
 
-A Go (golang) module for looking up information from [PWHOIS](https://pwhois.org/).
+[![Go Reference](https://pkg.go.dev/badge/github.com/georgestarcher/pwhois.svg)](https://pkg.go.dev/github.com/georgestarcher/pwhois)
+[![Go Report Card](https://goreportcard.com/badge/github.com/georgestarcher/pwhois)](https://goreportcard.com/report/github.com/georgestarcher/pwhois)
+[![CI](https://github.com/georgestarcher/pwhois/actions/workflows/go.yml/badge.svg)](https://github.com/georgestarcher/pwhois/actions/workflows/go.yml)
 
-Written by George Starcher with OpenAI ChatGPT v3.5 Jan 6rd, 2024
-  * https://help.openai.com/en/articles/6825453-chatgpt-release-notes
-  * https://chat.openai.com/share/f664e12a-e26f-4a64-96e2-8ecdf9008938
+`pwhois` is a Go module for querying a [PWHOIS](https://pwhois.org/) server and parsing its IP, routing, registry, and netblock responses.
 
-Referenced Original whob source:
-* [whob source code](https://pwhois.org/lft/)
+Originally written by George Starcher with OpenAI ChatGPT 3.5 on January 6, 2024. The implementation references the original [`whob` source code](https://github.com/irr/whob/blob/master/whob).
 
-MIT license, check license.txt for more information
-All text above must be included in any redistribution
+## Supported lookups
 
-## Installation
+- Individual or batched IP addresses
+- RouteView data for an autonomous system number (ASN)
+- Registry data for an ASN
+- Netblocks announced by an ASN
+
+## Install
 
 ```shell
 go get github.com/georgestarcher/pwhois
@@ -20,153 +23,59 @@ go get github.com/georgestarcher/pwhois
 
 ## Usage
 
-1. The maximum batch query size is 500 IP addresses. Going larger or querying too frequently could get you rate limited.
-2. Watch for error `ERROR: Unable to perform lookup; Daily query limit exceeded.` raised from the Lookup method. You have been rate limited by the phwois server.
-3. You can consider `server.MaxBatchSize = 100` or other value to protect your daily limit. `500` is the default.
-
-A go usage would be like the following. Note since each query is a network byte stream communications we make a connection for each query. 
-
-In the IP lookup you could add up to the `MaxBatchSize` number of IPs for a single query.
+Each lookup uses a TCP connection to a PWHOIS server. Close the connection when the lookup is complete. By default, batch IP lookups accept up to 500 addresses; callers should also respect the selected server's rate limits.
 
 ```go
-
 package main
 
 import (
 	"fmt"
-	"sync"
+	"log"
 
 	"github.com/georgestarcher/pwhois"
 )
 
 func main() {
+	server := new(pwhois.WhoisServer)
+	server.SetDefaultValues()
 
-	// A Connection for IP query
-	server1 := new(pwhois.WhoisServer)
-	server1.SetDefaultValues()
-	err := server1.Connect()
+	if err := server.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer server.Connection.Close()
+
+	query, err := server.FormatIpQuery([]string{"8.8.8.8"})
 	if err != nil {
-		fmt.Printf("%+v\n", err)
-	} else {
-		fmt.Printf("Connection Established to %+v\n", server1.Connection.RemoteAddr())
+		log.Fatal(err)
 	}
 
-	// A Connection for routeview query
-	server2 := new(pwhois.WhoisServer)
-	server2.SetDefaultValues()
-	err = server2.Connect()
-	if err != nil {
-		fmt.Printf("%+v\n", err)
-	} else {
-		fmt.Printf("Connection Established to %+v\n", server2.Connection.RemoteAddr())
+	responses := make(chan pwhois.IpLookupResponse, 1)
+	server.LookupIP(query, responses)
+	response := <-responses
+
+	if response.Error != nil {
+		log.Fatal(response.Error)
 	}
 
-	// A Connection for registry query
-	server3 := new(pwhois.WhoisServer)
-	server3.SetDefaultValues()
-	err = server3.Connect()
-	if err != nil {
-		fmt.Printf("%+v\n", err)
-	} else {
-		fmt.Printf("Connection Established to %+v\n", server3.Connection.RemoteAddr())
+	for _, record := range response.Response {
+		fmt.Printf("%s: AS%s (%s)\n", record.IP, record.OriginAS, record.OrgName)
 	}
-
-	// A Connection for netblock query
-	server4 := new(pwhois.WhoisServer)
-	server4.SetDefaultValues()
-	err = server4.Connect()
-	if err != nil {
-		fmt.Printf("%+v\n", err)
-	} else {
-		fmt.Printf("Connection Established to %+v\n", server4.Connection.RemoteAddr())
-	}
-
-	// Setup for the IP query
-	var wg sync.WaitGroup
-
-	c := make(chan pwhois.IpLookupResponse)
-
-	// IP lookup
-	valueIP := "8.8.8.8"
-	var values []string
-	values = append(values, valueIP)
-	query, err := server1.FormatIpQuery(values)
-	if err != nil {
-		fmt.Printf("%+v", err)
-	}
-
-	// Setup for the routeview query
-	c2 := make(chan pwhois.BGPLookupResponse)
-	valueASN := "15169"
-	queryRV, err := server2.FormatRouteViewQuery(valueASN)
-	if err != nil {
-		fmt.Printf("%+v\n", err)
-	}
-
-	// Setup for the registry query
-	c3 := make(chan pwhois.RegistryLookupResponse)
-	queryRegistry, err := server3.FormatRegistryQuery(valueASN)
-	if err != nil {
-		fmt.Printf("%+v\n", err)
-	}
-
-	// Setup for the netblock query
-	c4 := make(chan pwhois.NetblockLookupResponse)
-	queryNetblock, err := server3.FormatNetblockQuery(valueASN)
-	if err != nil {
-		fmt.Printf("%+v\n", err)
-	}
-
-	// Excute each connection/query as a goroutine
-	wg.Add(4)
-	go func() {
-		defer wg.Done()
-		server1.LookupIP(query, c)
-		server2.LookupRouteView(valueASN, queryRV, c2)
-		server3.LookupRegistry(valueASN, queryRegistry, c3)
-		server4.LookupNetblock(valueASN, queryNetblock, c4)
-	}()
-
-	// Get IP query results
-	whoisAnswer := <-c
-	if whoisAnswer.Error != nil {
-		fmt.Printf("ERROR: %+v\n", whoisAnswer.Error)
-	}
-
-	// Get routeview query results
-	asnAnswer := <-c2
-	if asnAnswer.Error != nil {
-		fmt.Printf("ERROR:%+v\n", asnAnswer.Error)
-	}
-
-	// Get registry query results
-	registryAnswer := <-c3
-	if registryAnswer.Error != nil {
-		fmt.Printf("ERROR:%+v\n", registryAnswer.Error)
-	}
-
-	// Get netblock query results
-	netblockAnswer := <-c4
-	if netblockAnswer.Error != nil {
-		fmt.Printf("ERROR:%+v\n", netblockAnswer.Error)
-	}
-
-	// Show results
-	fmt.Printf("IP Response:%+v\n", whoisAnswer.Response)
-	fmt.Printf("RouteView Response:%+v with # of Routes:%v\n", asnAnswer.Response.Asn, len(asnAnswer.Response.Routes))
-	fmt.Printf("Registration:%+v\n", registryAnswer.Response.Registry)
-	fmt.Printf("Netblock Response:%+v with # of Blocks:%v\n", netblockAnswer.Response.Asn, len(netblockAnswer.Response.Netblocks))
 }
 ```
 
-## pwhois Servers
+The other supported lookup types follow the same pattern. Use a separate connected `WhoisServer` for each lookup.
 
-Source: whob.c from the [whob source code](https://pwhois.org/lft/)
+| Lookup | Query formatter | Lookup method | Response type |
+| --- | --- | --- | --- |
+| IP | `FormatIpQuery` | `LookupIP` | `IpLookupResponse` |
+| RouteView | `FormatRouteViewQuery` | `LookupRouteView` | `BGPLookupResponse` |
+| Registry | `FormatRegistryQuery` | `LookupRegistry` | `RegistryLookupResponse` |
+| Netblock | `FormatNetblockQuery` | `LookupNetblock` | `NetblockLookupResponse` |
 
-* whois.pwhois.org
-* whois.ra.net
-* whois.cymru.com
-* whois.arin.net
-* whois.apnic.net
-* whois.ripe.net
-* riswhois.ripe.net
+## PWHOIS servers
+
+`SetDefaultValues` configures `whois.pwhois.org:43`. You can set `WhoisServer.Server` and `WhoisServer.Port` before calling `Connect`, but compatibility with alternative servers is not yet validated. Availability and rate limits are controlled by each server operator.
+
+## License
+
+Licensed under the [MIT License](LICENSE). See `LICENSE` for the copyright and permission notice that must accompany copies or substantial portions of the software.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # pwhois
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/georgestarcher/pwhois.svg)](https://pkg.go.dev/github.com/georgestarcher/pwhois)
-[![Go Report Card](https://goreportcard.com/badge/github.com/georgestarcher/pwhois)](https://goreportcard.com/report/github.com/georgestarcher/pwhois)
 [![CI](https://github.com/georgestarcher/pwhois/actions/workflows/go.yml/badge.svg)](https://github.com/georgestarcher/pwhois/actions/workflows/go.yml)
 
 `pwhois` is a Go module for querying a [PWHOIS](https://pwhois.org/) server and parsing its IP, routing, registry, and netblock responses.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `pwhois` is a Go module for querying a [PWHOIS](https://pwhois.org/) server and parsing its IP, routing, registry, and netblock responses.
 
-Originally written by George Starcher with OpenAI ChatGPT 3.5 on January 6, 2024. The implementation references the original [`whob` source code](https://github.com/irr/whob/blob/master/whob).
+Created by George Starcher. The implementation references the original [`whob` source code](https://github.com/irr/whob/blob/master/whob).
 
 ## Supported lookups
 

--- a/pwhois.go
+++ b/pwhois.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -40,6 +41,62 @@ func removeDuplicate[T string | int](sliceList []T) []T {
 // Utiliy function to check string is only digits
 func isOnlyDigits(s string) bool {
 	return regexp.MustCompile(`^\d+$`).MatchString(s)
+}
+
+// parseResponseLine splits a PWHOIS field without discarding delimiters in its
+// value. Response content is remote input, so malformed lines must produce an
+// error instead of panicking the caller.
+func parseResponseLine(line string) (string, string, error) {
+	key, value, ok := strings.Cut(line, ": ")
+	if !ok {
+		return "", "", fmt.Errorf("malformed response line: missing field delimiter")
+	}
+
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", "", fmt.Errorf("malformed response line: empty field name")
+	}
+
+	return key, strings.TrimSpace(value), nil
+}
+
+func parseResponseTime(field, value string, layouts ...string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+
+	for _, layout := range layouts {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("invalid %s value", field)
+}
+
+func parseResponseInt64(field, value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s value: %w", field, err)
+	}
+	return parsed, nil
+}
+
+func parseResponseFloat64(field, value string) (float64, error) {
+	if value == "" {
+		return 0, nil
+	}
+
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s value: %w", field, err)
+	}
+	return parsed, nil
 }
 
 // Whois server object

--- a/pwhois_ip.go
+++ b/pwhois_ip.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -80,7 +79,6 @@ func (server *WhoisServer) FormatIpQuery(values []string) (string, error) {
 func parseIpResponse(response string) ([]WhoIs, error) {
 
 	var responseWhoIs []WhoIs
-	responseMap := make(map[string]string)
 	responseRecords := strings.Split(response, "\n\n")
 
 	// Break the records apart and into the WhoIs structs
@@ -88,23 +86,47 @@ func parseIpResponse(response string) ([]WhoIs, error) {
 	if len(response) == 0 || len(responseRecords) == 0 {
 		return nil, fmt.Errorf("no records returned")
 	}
-	for _, record := range responseRecords {
+	for recordIndex, record := range responseRecords {
 		if len(record) == 0 {
 			continue
 		}
+		responseMap := make(map[string]string)
 		lines := strings.Split(record, "\n")
-		for _, line := range lines {
+		for lineIndex, line := range lines {
 			if len(line) == 0 {
 				continue
 			}
-			values := strings.Split(line, ": ")
-			responseMap[values[0]] = strings.Trim(values[1], " ")
-			if len(responseMap) == 0 {
-				continue
+			key, value, err := parseResponseLine(line)
+			if err != nil {
+				return nil, fmt.Errorf("parse IP response record %d line %d: %w", recordIndex+1, lineIndex+1, err)
 			}
+			responseMap[key] = value
 		}
-		latitudeFloat, _ := strconv.ParseFloat(responseMap["Latitude"], 64)
-		LongitudeFloat, _ := strconv.ParseFloat(responseMap["Longitude"], 64)
+		if len(responseMap) == 0 {
+			continue
+		}
+
+		latitudeFloat, err := parseResponseFloat64("Latitude", responseMap["Latitude"])
+		if err != nil {
+			return nil, fmt.Errorf("parse IP response record %d: %w", recordIndex+1, err)
+		}
+		longitudeFloat, err := parseResponseFloat64("Longitude", responseMap["Longitude"])
+		if err != nil {
+			return nil, fmt.Errorf("parse IP response record %d: %w", recordIndex+1, err)
+		}
+		cacheDate, err := parseResponseTime("Cache-Date", responseMap["Cache-Date"], "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse IP response record %d: %w", recordIndex+1, err)
+		}
+		routeOriginatedDate, err := parseResponseTime("Route-Originated-Date", responseMap["Route-Originated-Date"], "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse IP response record %d: %w", recordIndex+1, err)
+		}
+		routeOriginatedTS, err := parseResponseInt64("Route-Originated-TS", responseMap["Route-Originated-TS"])
+		if err != nil {
+			return nil, fmt.Errorf("parse IP response record %d: %w", recordIndex+1, err)
+		}
+
 		var whoIsParsedStruct WhoIs
 		whoIsParsedStruct.IP = responseMap["IP"]
 		whoIsParsedStruct.OriginAS = responseMap["Origin-AS"]
@@ -112,15 +134,15 @@ func parseIpResponse(response string) ([]WhoIs, error) {
 		whoIsParsedStruct.AsnOrgName = responseMap["AS-Org-Name"]
 		whoIsParsedStruct.OrgName = responseMap["Org-Name"]
 		whoIsParsedStruct.NetworkName = responseMap["Net-Name"]
-		whoIsParsedStruct.CacheDate, _ = time.Parse("Jan 02 2006 15:04:05", responseMap["Cache-Date"])
+		whoIsParsedStruct.CacheDate = cacheDate
 		whoIsParsedStruct.Latitude = latitudeFloat
-		whoIsParsedStruct.Longitude = LongitudeFloat
+		whoIsParsedStruct.Longitude = longitudeFloat
 		whoIsParsedStruct.City = responseMap["City"]
 		whoIsParsedStruct.Region = responseMap["Region"]
 		whoIsParsedStruct.Country = responseMap["Country"]
 		whoIsParsedStruct.CountryCode = responseMap["Country-Code"]
-		whoIsParsedStruct.RouteOriginatedDate, _ = time.Parse("Jan 02 2006 15:04:05", responseMap["Route-Originated-Date"])
-		whoIsParsedStruct.RouteOriginatedTS, _ = strconv.ParseInt(responseMap["Route-Originated-TS"], 10, 64)
+		whoIsParsedStruct.RouteOriginatedDate = routeOriginatedDate
+		whoIsParsedStruct.RouteOriginatedTS = routeOriginatedTS
 		responseWhoIs = append(responseWhoIs, whoIsParsedStruct)
 	}
 	return responseWhoIs, nil

--- a/pwhois_netblock.go
+++ b/pwhois_netblock.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -125,22 +124,30 @@ func parseNetblockResponse(asn string, response string) ([]NetblockRecord, error
 	}
 
 	// Process headerStrings
-	for _, line := range headerStrings {
+	for lineIndex, line := range headerStrings {
 		if len(line) == 0 {
 			continue
 		}
-		values := strings.Split(line, ": ")
-		responseMap[values[0]] = strings.Trim(values[1], " ")
-		if len(responseMap) == 0 {
-			continue
+		key, value, err := parseResponseLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("parse netblock header line %d: %w", lineIndex+1, err)
 		}
+		responseMap[key] = value
 	}
 
+	asValue, err := parseResponseInt64("AS", responseMap["AS"])
+	if err != nil {
+		return nil, fmt.Errorf("parse netblock header: %w", err)
+	}
+	orgValue, err := parseResponseInt64("Org", responseMap["Org"])
+	if err != nil {
+		return nil, fmt.Errorf("parse netblock header: %w", err)
+	}
 	responseRecord.Asn = asn
 	responseRecord.OriginAs = responseMap["AS"]
 	responseRecord.ASSource = responseMap["AS-Source"]
-	responseRecord.AS, _ = strconv.ParseInt(responseMap["AS"], 10, 64)
-	responseRecord.Org, _ = strconv.ParseInt(responseMap["Org"], 10, 64)
+	responseRecord.AS = asValue
+	responseRecord.Org = orgValue
 	responseRecord.OrgID = responseMap["Org-ID"]
 	responseRecord.OrgName = responseMap["Org-Name"]
 	responseRecord.OrgSource = responseMap["Org-Source"]
@@ -148,21 +155,33 @@ func parseNetblockResponse(asn string, response string) ([]NetblockRecord, error
 
 	// Process blockStrings
 
-	for _, line := range blockStrings {
+	for blockIndex, line := range blockStrings {
 		if len(line) == 0 {
 			continue
 		}
 		fields := strings.Fields(line)
 		if len(fields) < 23 {
-			continue // Skip invalid lines
+			return nil, fmt.Errorf("parse netblock record %d: expected at least 23 fields", blockIndex+1)
 		}
 		networkRange := fmt.Sprintf("%v-%v", fields[0], fields[2])
 		networkName := fields[4]
 		networkType := fields[6]
-		registerDate, _ := time.Parse("2006-01-02", fields[8])
-		updateDate, _ := time.Parse("2006-01-02", fields[10])
-		createDate, _ := time.Parse("Jan 02 2006 15:04:05", fmt.Sprintf("%s %s %s %s", fields[12], fields[13], fields[14], fields[15]))
-		modifyDate, _ := time.Parse("Jan 02 2006 15:04:05", fmt.Sprintf("%s %s %s %s", fields[17], fields[18], fields[19], fields[20]))
+		registerDate, err := parseResponseTime("Register-Date", fields[8], "2006-01-02")
+		if err != nil {
+			return nil, fmt.Errorf("parse netblock record %d: %w", blockIndex+1, err)
+		}
+		updateDate, err := parseResponseTime("Update-Date", fields[10], "2006-01-02")
+		if err != nil {
+			return nil, fmt.Errorf("parse netblock record %d: %w", blockIndex+1, err)
+		}
+		createDate, err := parseResponseTime("Create-Date", fmt.Sprintf("%s %s %s %s", fields[12], fields[13], fields[14], fields[15]), "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse netblock record %d: %w", blockIndex+1, err)
+		}
+		modifyDate, err := parseResponseTime("Modify-Date", fmt.Sprintf("%s %s %s %s", fields[17], fields[18], fields[19], fields[20]), "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse netblock record %d: %w", blockIndex+1, err)
+		}
 		source := fields[22]
 
 		block := Netblock{

--- a/pwhois_parser_test.go
+++ b/pwhois_parser_test.go
@@ -1,0 +1,247 @@
+package pwhois
+
+import (
+	"io"
+	"net"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseResponseLine(t *testing.T) {
+	key, value, err := parseResponseLine("Comment: first: second")
+	if err != nil {
+		t.Fatalf("parse response line: %v", err)
+	}
+	if key != "Comment" || value != "first: second" {
+		t.Fatalf("unexpected field: key=%q value=%q", key, value)
+	}
+
+	if _, _, err := parseResponseLine("malformed response line"); err == nil {
+		t.Fatal("expected malformed response line to return an error")
+	}
+}
+
+func TestParseIpResponseIsolatesRecords(t *testing.T) {
+	response := strings.Join([]string{
+		"IP: 192.0.2.1",
+		"Prefix: 192.0.2.0/24",
+		"Org-Name: First: Network",
+		"Cache-Date: Jul 18 2026 07:19:28",
+		"Latitude: 37.405992",
+		"Longitude: -122.078515",
+		"Route-Originated-Date: Mar 12 2026 15:22:33",
+		"Route-Originated-TS: 1773328953",
+		"",
+		"IP: 192.0.2.2",
+	}, "\n")
+
+	records, err := parseIpResponse(response)
+	if err != nil {
+		t.Fatalf("parse IP response: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("record count: got %d, want 2", len(records))
+	}
+	if records[0].OrgName != "First: Network" {
+		t.Fatalf("first organization: got %q", records[0].OrgName)
+	}
+	if records[1].OrgName != "" {
+		t.Fatalf("second record inherited organization %q", records[1].OrgName)
+	}
+	if !records[1].CacheDate.IsZero() {
+		t.Fatalf("second record inherited cache date %v", records[1].CacheDate)
+	}
+}
+
+func TestParseIpResponseRejectsMalformedValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "line", response: "IP 192.0.2.1"},
+		{name: "latitude", response: "IP: 192.0.2.1\nLatitude: invalid"},
+		{name: "date", response: "IP: 192.0.2.1\nCache-Date: invalid"},
+		{name: "timestamp", response: "IP: 192.0.2.1\nRoute-Originated-TS: invalid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseIpResponse(test.response); err == nil {
+				t.Fatal("expected malformed IP response to return an error")
+			}
+		})
+	}
+}
+
+func TestParseRegistryResponseIsolatesRecords(t *testing.T) {
+	response := strings.Join([]string{
+		"Org-ID: FIRST",
+		"Org-Name: First: Organization",
+		"Can-Allocate: 1",
+		"State: NJ",
+		"Register-Date: 2001-09-18",
+		"",
+		"Org-ID: SECOND",
+		"Can-Allocate: 0",
+	}, "\n")
+
+	records, err := parseRegistryResponse(response)
+	if err != nil {
+		t.Fatalf("parse registry response: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("record count: got %d, want 2", len(records))
+	}
+	if records[0].OrgName != "First: Organization" {
+		t.Fatalf("first organization: got %q", records[0].OrgName)
+	}
+	if !records[0].CanAllocate {
+		t.Fatal("expected numeric Can-Allocate value 1 to parse as true")
+	}
+	if records[0].RegisterDate.IsZero() {
+		t.Fatal("expected ISO register date to be parsed")
+	}
+	if records[1].OrgName != "" {
+		t.Fatalf("second record inherited organization %q", records[1].OrgName)
+	}
+	if records[1].CanAllocate {
+		t.Fatal("expected numeric Can-Allocate value 0 to parse as false")
+	}
+}
+
+func TestParseRegistryResponseRejectsMalformedValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "line", response: "Org-ID FIRST"},
+		{name: "boolean", response: "Org-ID: FIRST\nCan-Allocate: sometimes"},
+		{name: "date", response: "Org-ID: FIRST\nRegister-Date: invalid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseRegistryResponse(test.response); err == nil {
+				t.Fatal("expected malformed registry response to return an error")
+			}
+		})
+	}
+}
+
+func TestParseBgpResponseRejectsMalformedRoutes(t *testing.T) {
+	validRoute := "*> 4.0.0.0/9 | Jul 18 2026 00:00:04 | Jul 18 2026 00:00:04 | May 28 2026 06:56:01 | 208.115.137.35 | 8220 1299 3356"
+	routes, err := parseBgpResponse("Origin-AS: 3356\n" + validRoute)
+	if err != nil {
+		t.Fatalf("parse valid route: %v", err)
+	}
+	if len(routes) != 1 || len(routes[0].ASPath) != 3 {
+		t.Fatalf("unexpected valid route result: %+v", routes)
+	}
+
+	malformed := []string{
+		"Origin-AS: 3356\n*> too short",
+		"Origin-AS: 3356\n" + strings.Replace(validRoute, "1299", "invalid", 1),
+		"Origin-AS: 3356\nno route records",
+	}
+	for _, response := range malformed {
+		if _, err := parseBgpResponse(response); err == nil {
+			t.Fatalf("expected malformed route response to fail: %q", response)
+		}
+	}
+}
+
+func TestParseNetblockResponseRejectsMalformedBlocks(t *testing.T) {
+	valid := strings.Join([]string{
+		"Origin-AS: 13335",
+		"AS: 0",
+		"Org: 0",
+		"Org-Name: Example: Networks",
+		"*> 8.6.112.0 - 8.6.112.255 | EXAMPLE-NET | reassignment | 2019-05-25 | 2019-09-25 | Jun 28 2019 16:53:01 | Jul 18 2026 03:19:32 | ARIN",
+	}, "\n")
+
+	records, err := parseNetblockResponse("13335", valid)
+	if err != nil {
+		t.Fatalf("parse valid netblock response: %v", err)
+	}
+	if len(records) != 1 || records[0].OrgName != "Example: Networks" {
+		t.Fatalf("unexpected valid netblock result: %+v", records)
+	}
+	if len(records[0].Netblocks) != 1 {
+		t.Fatalf("netblock count: got %d, want 1", len(records[0].Netblocks))
+	}
+
+	malformed := strings.Join([]string{
+		"Origin-AS: 13335",
+		"AS: 0",
+		"Org: 0",
+		"*> too short",
+	}, "\n")
+	if _, err := parseNetblockResponse("13335", malformed); err == nil {
+		t.Fatal("expected malformed netblock record to return an error")
+	}
+}
+
+func TestLookupRegistryDoesNotWriteStdout(t *testing.T) {
+	clientConnection, serverConnection := net.Pipe()
+	defer clientConnection.Close()
+
+	query := "registry query\n"
+	serverResult := make(chan error, 1)
+	go func() {
+		defer serverConnection.Close()
+		request := make([]byte, len(query))
+		if _, err := io.ReadFull(serverConnection, request); err != nil {
+			serverResult <- err
+			return
+		}
+		_, err := io.WriteString(serverConnection, "Org-ID: EXAMPLE\nOrg-Name: Example Organization\n")
+		serverResult <- err
+	}()
+
+	lookupResult := make(chan RegistryLookupResponse, 1)
+	server := WhoisServer{Connection: clientConnection}
+	var response RegistryLookupResponse
+	output := captureStdout(t, func() {
+		server.LookupRegistry("64500", query, lookupResult)
+		response = <-lookupResult
+	})
+
+	if err := <-serverResult; err != nil {
+		t.Fatalf("serve synthetic registry response: %v", err)
+	}
+	if response.Error != nil {
+		t.Fatalf("lookup registry: %v", response.Error)
+	}
+	if output != "" {
+		t.Fatalf("LookupRegistry wrote to stdout: %q", output)
+	}
+}
+
+func captureStdout(t *testing.T, function func()) string {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout capture pipe: %v", err)
+	}
+	original := os.Stdout
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = original
+		reader.Close()
+		writer.Close()
+	}()
+
+	function()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout capture writer: %v", err)
+	}
+	os.Stdout = original
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	return string(output)
+}

--- a/pwhois_registry.go
+++ b/pwhois_registry.go
@@ -67,7 +67,6 @@ func (server *WhoisServer) FormatRegistryQuery(asn string) (string, error) {
 func parseRegistryResponse(response string) ([]Registry, error) {
 
 	var responseRegistry []Registry
-	responseMap := make(map[string]string)
 	responseRecords := strings.Split(response, "\n\n")
 
 	// Break the records apart and into the WhoIs structs
@@ -75,36 +74,62 @@ func parseRegistryResponse(response string) ([]Registry, error) {
 	if len(response) == 0 || len(responseRecords) == 0 {
 		return nil, fmt.Errorf("no records returned")
 	}
-	for _, record := range responseRecords {
+	for recordIndex, record := range responseRecords {
 		if len(record) == 0 {
 			continue
 		}
+		responseMap := make(map[string]string)
 		lines := strings.Split(record, "\n")
-		for _, line := range lines {
+		for lineIndex, line := range lines {
 			if len(line) == 0 {
 				continue
 			}
-			values := strings.Split(line, ": ")
-			responseMap[values[0]] = strings.Trim(values[1], " ")
-			if len(responseMap) == 0 {
-				continue
+			key, value, err := parseResponseLine(line)
+			if err != nil {
+				return nil, fmt.Errorf("parse registry response record %d line %d: %w", recordIndex+1, lineIndex+1, err)
 			}
+			responseMap[key] = value
 		}
+		if len(responseMap) == 0 {
+			continue
+		}
+
+		canAllocate, err := parseCanAllocate(responseMap["Can-Allocate"])
+		if err != nil {
+			return nil, fmt.Errorf("parse registry response record %d: %w", recordIndex+1, err)
+		}
+		registerDate, err := parseResponseTime("Register-Date", responseMap["Register-Date"], "2006-01-02", "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse registry response record %d: %w", recordIndex+1, err)
+		}
+		updateDate, err := parseResponseTime("Update-Date", responseMap["Update-Date"], "2006-01-02", "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse registry response record %d: %w", recordIndex+1, err)
+		}
+		createDate, err := parseResponseTime("Create-Date", responseMap["Create-Date"], "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse registry response record %d: %w", recordIndex+1, err)
+		}
+		modifyDate, err := parseResponseTime("Modify-Date", responseMap["Modify-Date"], "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse registry response record %d: %w", recordIndex+1, err)
+		}
+
 		var registryParsedStruct Registry
 		registryParsedStruct.OrgRecord = responseMap["Org-Record"]
 		registryParsedStruct.OrgID = responseMap["Org-ID"]
 		registryParsedStruct.OrgName = responseMap["Org-Name"]
-		registryParsedStruct.CanAllocate, _ = strconv.ParseBool(responseMap["Can-Allocate"])
+		registryParsedStruct.CanAllocate = canAllocate
 		registryParsedStruct.Source = responseMap["Source"]
 		registryParsedStruct.Street1 = responseMap["Street-1"]
 		registryParsedStruct.City = responseMap["City"]
 		registryParsedStruct.Region = responseMap["Region"]
 		registryParsedStruct.Country = responseMap["Country"]
 		registryParsedStruct.CountryCode = responseMap["Country-Code"]
-		registryParsedStruct.RegisterDate, _ = time.Parse("Jan 02 2006 15:04:05", responseMap["Register-Date"])
-		registryParsedStruct.UpdateDate, _ = time.Parse("Jan 02 2006 15:04:05", responseMap["Update-Date"])
-		registryParsedStruct.CreateDate, _ = time.Parse("Jan 02 2006 15:04:05", responseMap["Create-Date"])
-		registryParsedStruct.ModifyDate, _ = time.Parse("Jan 02 2006 15:04:05", responseMap["Modify-Date"])
+		registryParsedStruct.RegisterDate = registerDate
+		registryParsedStruct.UpdateDate = updateDate
+		registryParsedStruct.CreateDate = createDate
+		registryParsedStruct.ModifyDate = modifyDate
 		registryParsedStruct.AdminHandle0 = responseMap["Admin-0-Handle"]
 		registryParsedStruct.AbuseHandle0 = responseMap["Abuse-0-Handle"]
 		registryParsedStruct.TechHandle0 = responseMap["CTech-0-Handle"]
@@ -113,6 +138,21 @@ func parseRegistryResponse(response string) ([]Registry, error) {
 		responseRegistry = append(responseRegistry, registryParsedStruct)
 	}
 	return responseRegistry, nil
+}
+
+func parseCanAllocate(value string) (bool, error) {
+	switch value {
+	case "", "0":
+		return false, nil
+	case "1":
+		return true, nil
+	default:
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return false, fmt.Errorf("invalid Can-Allocate value: %w", err)
+		}
+		return parsed, nil
+	}
 }
 
 /*
@@ -150,10 +190,6 @@ func (server WhoisServer) LookupRegistry(asn string, query string, c chan Regist
 	if err != nil {
 		c <- RegistryLookupResponse{Answer, err}
 		return
-	}
-
-	for _, line := range strings.Split(buf.String(), "\n") {
-		fmt.Println(line)
 	}
 
 	// Check for daily limit and raise error

--- a/pwhois_routeview.go
+++ b/pwhois_routeview.go
@@ -55,26 +55,48 @@ func parseBgpResponse(response string) ([]BGPRoute, error) {
 		return nil, fmt.Errorf("no records returned")
 
 	}
-	return parseBGPData(response), nil
+	routes, err := parseBGPData(response)
+	if err != nil {
+		return nil, err
+	}
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("no routes returned")
+	}
+	return routes, nil
 }
 
 // Parse BGP route data from string
-func parseBGPData(data string) []BGPRoute {
+func parseBGPData(data string) ([]BGPRoute, error) {
 	var routes []BGPRoute
 
 	lines := strings.Split(data, "\n")
-	for _, line := range lines {
+	for lineIndex, line := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(line), "*>") {
+			continue
+		}
 		fields := strings.Fields(line)
-		if len(fields) < 20 {
-			continue // Skip invalid lines
+		if len(fields) < 21 {
+			return nil, fmt.Errorf("parse route record at line %d: expected at least 21 fields", lineIndex+1)
 		}
 
 		prefix := fields[1]
-		createDate, _ := time.Parse("Jan 02 2006 15:04:05", fmt.Sprintf("%s %s %s %s", fields[3], fields[4], fields[5], fields[6]))
-		modifyDate, _ := time.Parse("Jan 02 2006 15:04:05", fmt.Sprintf("%s %s %s %s", fields[8], fields[9], fields[10], fields[11]))
-		originatedDate, _ := time.Parse("Jan 02 2006 15:04:05", fmt.Sprintf("%s %s %s %s", fields[13], fields[14], fields[15], fields[16]))
+		createDate, err := parseResponseTime("Create-Date", fmt.Sprintf("%s %s %s %s", fields[3], fields[4], fields[5], fields[6]), "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse route record at line %d: %w", lineIndex+1, err)
+		}
+		modifyDate, err := parseResponseTime("Modify-Date", fmt.Sprintf("%s %s %s %s", fields[8], fields[9], fields[10], fields[11]), "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse route record at line %d: %w", lineIndex+1, err)
+		}
+		originatedDate, err := parseResponseTime("Originated-Date", fmt.Sprintf("%s %s %s %s", fields[13], fields[14], fields[15], fields[16]), "Jan 02 2006 15:04:05")
+		if err != nil {
+			return nil, fmt.Errorf("parse route record at line %d: %w", lineIndex+1, err)
+		}
 		nextHop := fields[18]
-		asPath := parseASPath(fields[20:])
+		asPath, err := parseASPath(fields[20:])
+		if err != nil {
+			return nil, fmt.Errorf("parse route record at line %d: %w", lineIndex+1, err)
+		}
 
 		route := BGPRoute{
 			Prefix:         prefix,
@@ -87,17 +109,20 @@ func parseBGPData(data string) []BGPRoute {
 
 		routes = append(routes, route)
 	}
-	return routes
+	return routes, nil
 }
 
 // Parse AS number path
-func parseASPath(asPathFields []string) []int {
+func parseASPath(asPathFields []string) ([]int, error) {
 	var asPath []int
-	for _, asStr := range asPathFields {
-		as, _ := strconv.Atoi(asStr)
+	for index, asStr := range asPathFields {
+		as, err := strconv.Atoi(asStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid AS path value at position %d: %w", index+1, err)
+		}
 		asPath = append(asPath, as)
 	}
-	return asPath
+	return asPath, nil
 }
 
 /*


### PR DESCRIPTION
## Summary

Harden all PWHOIS response parsers against malformed remote data, isolate per-record parser state, stop registry lookups from printing raw responses, and replace the broken README example with a minimal copyable one.

## What changed

- replace unchecked `strings.Split` indexing with a shared `strings.Cut`-based field parser that preserves embedded delimiters
- return contextual errors for malformed field lines, fixed-width route/netblock records, numeric values, dates, booleans, and AS paths
- initialize IP and registry response maps for each record so omitted fields cannot inherit prior-record values
- accept the service's numeric `Can-Allocate` values and ISO registry dates while retaining the prior timestamp format
- return an error when a non-empty routeview response contains no usable routes
- remove unconditional registry-response output from `LookupRegistry`
- add deterministic regression coverage for every parser and a local `net.Pipe` lookup proving stdout stays empty
- replace the misleading multi-lookup README sample with a small single-IP example verified against the current public API
- clarify supported lookups, connection ownership, default server behavior, and alternative-server compatibility status
- link the README to the correctly named `LICENSE` file and align its wording with the canonical MIT terms

## Root cause

The parsers trusted remote response shape, indexed split results without validating them, ignored conversion errors, and reused maps across multi-record responses. Registry lookup also contained a leftover debug print loop. The README example had stale field/type names, mismatched query and connection variables, incomplete synchronization, and no connection cleanup.

## Compatibility

No exported function signatures or JSON field types changed. Valid server responses retain their existing public result types; malformed values now return errors instead of panicking or silently becoming zero values. The existing `LICENSE` file already contains the canonical MIT text and retains its original 2024 copyright notice.

## Validation

- exact README program compiled as a temporary package
- focused deterministic parser/stdout tests repeated 20 times
- `go test ./... -count=1 -timeout 30s`
- `go vet ./...`
- `go test -race ./... -count=1 -timeout 45s`
- `go build ./...`
- `git diff --check`

Closes #18
Closes #19
Closes #20
Closes #26

Addresses the README license-link portion of #27 without closing the broader community-health issue.
