### PR TITLE
Make default tests deterministic and refresh CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,29 +1,41 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: pwhois CI
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
+  workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-
-  build:
+  validate:
+    name: Build, vet, and test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.21.5'
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: false
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./... 
+      - name: Vet
+        run: go vet ./...
 
+      - name: Test
+        run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ The other supported lookup types follow the same pattern. Use a separate connect
 
 `SetDefaultValues` configures `whois.pwhois.org:43`. You can set `WhoisServer.Server` and `WhoisServer.Port` before calling `Connect`, but compatibility with alternative servers is not yet validated. Availability and rate limits are controlled by each server operator.
 
+## Development
+
+The default checks are deterministic and do not contact public PWHOIS servers:
+
+```shell
+go test ./...
+go vet ./...
+go build ./...
+```
+
+Live integration tests use `whois.pwhois.org:43` and must be requested explicitly:
+
+```shell
+go test -tags=integration ./...
+```
+
+The live tests depend on the public service's availability, response data, and rate limits, so they are not part of the default GitHub Actions workflow.
+
 ## License
 
 Licensed under the [MIT License](LICENSE). See `LICENSE` for the copyright and permission notice that must accompany copies or substantial portions of the software.

--- a/pwhois_integration_test.go
+++ b/pwhois_integration_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package pwhois
+
+import "testing"
+
+func connectIntegrationServer(t *testing.T) *WhoisServer {
+	t.Helper()
+
+	server := new(WhoisServer)
+	server.SetDefaultValues()
+	if err := server.Connect(); err != nil {
+		t.Fatalf("connect to %s: %v", server.ServerAddressString(), err)
+	}
+	t.Cleanup(func() {
+		if err := server.Connection.Close(); err != nil {
+			t.Errorf("close connection to %s: %v", server.ServerAddressString(), err)
+		}
+	})
+
+	return server
+}
+
+func TestIntegrationConnect(t *testing.T) {
+	server := connectIntegrationServer(t)
+	t.Logf("connection established to %s", server.Connection.RemoteAddr())
+}
+
+func TestIntegrationIpLookup(t *testing.T) {
+	server := connectIntegrationServer(t)
+	query, err := server.FormatIpQuery([]string{"8.8.8.8", "1.1.1.1", "8.8.8.8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	responses := make(chan IpLookupResponse, 1)
+	server.LookupIP(query, responses)
+	response := <-responses
+	if response.Error != nil {
+		t.Fatalf("lookup IPs: %v", response.Error)
+	}
+	if got, want := len(response.Response), 2; got != want {
+		t.Errorf("response count: got %d, want %d", got, want)
+	}
+}
+
+func TestIntegrationRouteViewLookup(t *testing.T) {
+	server := connectIntegrationServer(t)
+	const asn = "3356"
+	query, err := server.FormatRouteViewQuery(asn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	responses := make(chan BGPLookupResponse, 1)
+	server.LookupRouteView(asn, query, responses)
+	response := <-responses
+	if response.Error != nil {
+		t.Fatalf("lookup RouteView data: %v", response.Error)
+	}
+	if got := len(response.Response.Routes); got < 2 {
+		t.Errorf("route count: got %d, want at least 2", got)
+	}
+}
+
+func TestIntegrationRegistryLookup(t *testing.T) {
+	server := connectIntegrationServer(t)
+	const asn = "7922"
+	query, err := server.FormatRegistryQuery(asn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	responses := make(chan RegistryLookupResponse, 1)
+	server.LookupRegistry(asn, query, responses)
+	response := <-responses
+	if response.Error != nil {
+		t.Fatalf("lookup registry data: %v", response.Error)
+	}
+	if got, want := response.Response.Registry.OrgName, "Comcast Cable Communications, LLC"; got != want {
+		t.Errorf("organization name: got %q, want %q", got, want)
+	}
+}
+
+func TestIntegrationNetblockLookup(t *testing.T) {
+	server := connectIntegrationServer(t)
+	const asn = "13335"
+	query, err := server.FormatNetblockQuery(asn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	responses := make(chan NetblockLookupResponse, 1)
+	server.LookupNetblock(asn, query, responses)
+	response := <-responses
+	if response.Error != nil {
+		t.Fatalf("lookup netblock data: %v", response.Error)
+	}
+	if got, want := response.Response.OrgName, "Cloudflare, Inc."; got != want {
+		t.Errorf("organization name: got %q, want %q", got, want)
+	}
+}

--- a/pwhois_ip_test.go
+++ b/pwhois_ip_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"sync"
 	"testing"
 )
 
@@ -80,53 +79,5 @@ func TestFormatIpQuery(t *testing.T) {
 				t.Errorf("Expected %v, got %v", c.expected, got)
 			}
 		})
-	}
-}
-
-// Test ip lookup against default pwhois
-func TestIpLookup(t *testing.T) {
-
-	server := new(WhoisServer)
-	server.SetDefaultValues()
-	err := server.Connect()
-
-	if err != nil {
-		t.Errorf("got %v", err)
-	}
-
-	// process lookup of values
-	var wg sync.WaitGroup
-
-	c := make(chan IpLookupResponse)
-
-	value1 := "8.8.8.8"
-	value2 := "1.1.1.1"
-	value3 := "8.8.8.8"
-	var values []string
-	values = append(values, value1)
-	values = append(values, value2)
-	values = append(values, value3)
-	query, err := server.FormatIpQuery(values)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		server.LookupIP(query, c)
-	}()
-
-	whoisAnswer := <-c
-	if whoisAnswer.Error != nil {
-		t.Fatalf("ERROR: %v\n", whoisAnswer.Error)
-	}
-	t.Logf("Query Response:%+v\n", whoisAnswer.Response)
-
-	got := len(whoisAnswer.Response)
-	want := 2
-
-	if got != want {
-		t.Errorf("Response Count: got %v, wanted %v", got, want)
 	}
 }

--- a/pwhois_netblock_test.go
+++ b/pwhois_netblock_test.go
@@ -2,7 +2,6 @@ package pwhois
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 )
 
@@ -53,47 +52,5 @@ func TestFormatNetblockQuery(t *testing.T) {
 				t.Errorf("Expected %v, got %v", c.expected, got)
 			}
 		})
-	}
-}
-
-// Test routeview lookup against default pwhois
-func TestLookupNetblock(t *testing.T) {
-
-	server := new(WhoisServer)
-	server.SetDefaultValues()
-	err := server.Connect()
-
-	if err != nil {
-		t.Errorf("got %v", err)
-	}
-
-	// process lookup of values
-	var wg sync.WaitGroup
-
-	c := make(chan NetblockLookupResponse)
-
-	value := "13335"
-
-	query, err := server.FormatNetblockQuery(value)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		server.LookupNetblock(value, query, c)
-	}()
-
-	netblockAnswer := <-c
-	if netblockAnswer.Error != nil {
-		t.Fatalf("ERROR: %v\n", netblockAnswer.Error)
-	}
-
-	got := netblockAnswer.Response.OrgName
-	want := "Cloudflare, Inc."
-
-	if got != want {
-		t.Errorf("Response Count: got %v, wanted %v", got, want)
 	}
 }

--- a/pwhois_registry_test.go
+++ b/pwhois_registry_test.go
@@ -2,7 +2,6 @@ package pwhois
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 )
 
@@ -47,47 +46,5 @@ func TestFormatRegistryQuery(t *testing.T) {
 				t.Errorf("Expected %v, got %v", c.expected, got)
 			}
 		})
-	}
-}
-
-// Test routeview lookup against default pwhois
-func TestLookupRegistry(t *testing.T) {
-
-	server := new(WhoisServer)
-	server.SetDefaultValues()
-	err := server.Connect()
-
-	if err != nil {
-		t.Errorf("got %v", err)
-	}
-
-	// process lookup of values
-	var wg sync.WaitGroup
-
-	c := make(chan RegistryLookupResponse)
-
-	value := "7922"
-
-	query, err := server.FormatRegistryQuery(value)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		server.LookupRegistry(value, query, c)
-	}()
-
-	registryAnswer := <-c
-	if registryAnswer.Error != nil {
-		t.Fatalf("ERROR: %v\n", registryAnswer.Error)
-	}
-
-	got := registryAnswer.Response.Registry.OrgName
-	want := "Comcast Cable Communications, LLC"
-
-	if got != want {
-		t.Errorf("Response Count: got %v, wanted %v", got, want)
 	}
 }

--- a/pwhois_routeview_test.go
+++ b/pwhois_routeview_test.go
@@ -2,7 +2,6 @@ package pwhois
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 )
 
@@ -47,47 +46,5 @@ func TestFormatRouteviewQuery(t *testing.T) {
 				t.Errorf("Expected %v, got %v", c.expected, got)
 			}
 		})
-	}
-}
-
-// Test routeview lookup against default pwhois
-func TestLookupRouteView(t *testing.T) {
-
-	server := new(WhoisServer)
-	server.SetDefaultValues()
-	err := server.Connect()
-
-	if err != nil {
-		t.Errorf("got %v", err)
-	}
-
-	// process lookup of values
-	var wg sync.WaitGroup
-
-	c := make(chan BGPLookupResponse)
-
-	value := "3356"
-
-	query, err := server.FormatRouteViewQuery(value)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		server.LookupRouteView(value, query, c)
-	}()
-
-	asnAnswer := <-c
-	if asnAnswer.Error != nil {
-		t.Fatalf("ERROR: %v\n", asnAnswer.Error)
-	}
-
-	got := len(asnAnswer.Response.Routes[:2])
-	want := 2
-
-	if got != want {
-		t.Errorf("Response Count: got %v, wanted %v", got, want)
 	}
 }

--- a/pwhois_test.go
+++ b/pwhois_test.go
@@ -41,16 +41,3 @@ func TestSetDefaultValues(t *testing.T) {
 		})
 	}
 }
-
-// Test connection to default pwhois server
-func TestConnect(t *testing.T) {
-
-	server := new(WhoisServer)
-	server.SetDefaultValues()
-	err := server.Connect()
-	if err != nil {
-		t.Errorf("got %v", err)
-	} else {
-		t.Logf("Connection Established to %+v\n", server.Connection.RemoteAddr())
-	}
-}


### PR DESCRIPTION
## Summary

Separate all public PWHOIS network checks from the default test suite and refresh GitHub Actions so pull requests run a deterministic build, vet, and test path.

## What changed

- move the five live connection and lookup checks into `pwhois_integration_test.go` behind the `integration` build tag
- keep live IP, RouteView, registry, and netblock coverage available through `go test -tags=integration ./...`
- close every live test connection with test cleanup and avoid unnecessary goroutines and wait groups
- document deterministic local checks and the explicit live-test command in the README
- update GitHub Actions to `actions/checkout@v7` and `actions/setup-go@v7`
- read the Go version from `go.mod`, disable unnecessary caching, and prevent checkout credentials from persisting
- add read-only workflow permissions, concurrency cancellation, manual dispatch, `go vet`, and a job timeout

## Impact

`go test ./...` no longer depends on public network access, PWHOIS availability, changing public response data, or rate limits. Live service behavior remains testable on demand and is intentionally excluded from ordinary CI.

## Validation

- confirmed the default Go test file list excludes `pwhois_integration_test.go`
- confirmed `-tags=integration` includes the integration file
- compiled the integration-tagged suite without running tests
- `go test ./... -count=10 -timeout 30s`
- `go vet ./...`
- `go test -race ./... -count=1 -timeout 45s`
- `go build ./...`
- live `go test -tags=integration -run '^TestIntegration' -v -count=1 -timeout 90s ./...` (all five tests passed)
- `git diff --check`

Closes #17
Closes #23
