### PR TITLE
Normalize ASN query inputs

### DIFF
--- a/pwhois.go
+++ b/pwhois.go
@@ -1,6 +1,7 @@
 package pwhois
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -41,6 +42,21 @@ func removeDuplicate[T string | int](sliceList []T) []T {
 // Utiliy function to check string is only digits
 func isOnlyDigits(s string) bool {
 	return regexp.MustCompile(`^\d+$`).MatchString(s)
+}
+
+// normalizeASN accepts decimal ASNs with an optional case-insensitive AS
+// prefix. All ASN query formatters use it so they accept and reject the same
+// inputs.
+func normalizeASN(value string) (string, error) {
+	asn := strings.TrimSpace(value)
+	if len(asn) >= 2 && strings.EqualFold(asn[:2], "AS") {
+		asn = asn[2:]
+	}
+	if !isOnlyDigits(asn) {
+		return "", errors.New("invalid ASN value")
+	}
+
+	return asn, nil
 }
 
 // parseResponseLine splits a PWHOIS field without discarding delimiters in its

--- a/pwhois_asn_test.go
+++ b/pwhois_asn_test.go
@@ -1,0 +1,66 @@
+package pwhois
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestASNQueryFormattersNormalizeInputsConsistently(t *testing.T) {
+	server := new(WhoisServer)
+	server.SetDefaultValues()
+
+	formatters := []struct {
+		name   string
+		format func(string) (string, error)
+		query  string
+	}{
+		{"RouteView", server.FormatRouteViewQuery, "routeview"},
+		{"Registry", server.FormatRegistryQuery, "registry"},
+		{"Netblock", server.FormatNetblockQuery, "netblock"},
+	}
+	tests := []struct {
+		name          string
+		input         string
+		normalizedASN string
+		wantErr       bool
+	}{
+		{name: "bare number", input: "123"},
+		{name: "uppercase prefix", input: "AS123", normalizedASN: "123"},
+		{name: "lowercase prefix", input: "as123", normalizedASN: "123"},
+		{name: "surrounding whitespace", input: " AS123 ", normalizedASN: "123"},
+		{name: "empty", input: "", wantErr: true},
+		{name: "prefix only", input: "AS", wantErr: true},
+		{name: "prefix with space", input: "AS 123", wantErr: true},
+		{name: "non-numeric", input: "AS12x", wantErr: true},
+		{name: "IP address", input: "8.8.8.8", wantErr: true},
+	}
+
+	for _, formatter := range formatters {
+		for _, test := range tests {
+			t.Run(formatter.name+"/"+test.name, func(t *testing.T) {
+				got, err := formatter.format(test.input)
+				if test.wantErr {
+					if err == nil {
+						t.Fatal("expected an error")
+					}
+					if got != "" {
+						t.Fatalf("query on invalid input: got %q", got)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("format query: %v", err)
+				}
+
+				normalizedASN := test.normalizedASN
+				if normalizedASN == "" {
+					normalizedASN = test.input
+				}
+				want := fmt.Sprintf("app=\"%s\" %s source-as=%s\n", AppName, formatter.query, normalizedASN)
+				if got != want {
+					t.Errorf("query: got %q, want %q", got, want)
+				}
+			})
+		}
+	}
+}

--- a/pwhois_netblock.go
+++ b/pwhois_netblock.go
@@ -48,15 +48,11 @@ args:
 */
 func (server *WhoisServer) FormatNetblockQuery(asn string) (string, error) {
 
-	if len(asn) == 0 {
-		return "", fmt.Errorf("no valid value provided")
+	normalizedASN, err := normalizeASN(asn)
+	if err != nil {
+		return "", err
 	}
-
-	asn = strings.TrimPrefix(asn, "AS")
-	if !isOnlyDigits(asn) {
-		return "", fmt.Errorf("invalid asn value")
-	}
-	queryString := fmt.Sprintf("app=\"%s\" netblock source-as=%s\n", AppName, asn)
+	queryString := fmt.Sprintf("app=\"%s\" netblock source-as=%s\n", AppName, normalizedASN)
 
 	return queryString, nil
 }

--- a/pwhois_netblock_test.go
+++ b/pwhois_netblock_test.go
@@ -21,13 +21,13 @@ func TestFormatNetblockQuery(t *testing.T) {
 			name:     "EmptyValue",
 			value:    "",
 			expected: "",
-			err:      fmt.Errorf("no valid value provided"),
+			err:      fmt.Errorf("invalid ASN value"),
 		},
 		{
 			name:     "InvalidValue",
 			value:    "8.8.8.8",
 			expected: "",
-			err:      fmt.Errorf("invalid asn value"),
+			err:      fmt.Errorf("invalid ASN value"),
 		},
 		{
 			name:     "ValidValue",

--- a/pwhois_registry.go
+++ b/pwhois_registry.go
@@ -2,7 +2,6 @@ package pwhois
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -54,11 +53,11 @@ args:
 */
 func (server *WhoisServer) FormatRegistryQuery(asn string) (string, error) {
 
-	if len(asn) == 0 {
-		return "", errors.New("no valid value provided")
+	normalizedASN, err := normalizeASN(asn)
+	if err != nil {
+		return "", err
 	}
-	asn = strings.TrimPrefix(asn, "AS")
-	queryString := fmt.Sprintf("app=\"%s\" registry source-as=%s\n", AppName, asn)
+	queryString := fmt.Sprintf("app=\"%s\" registry source-as=%s\n", AppName, normalizedASN)
 
 	return queryString, nil
 }

--- a/pwhois_registry_test.go
+++ b/pwhois_registry_test.go
@@ -21,7 +21,7 @@ func TestFormatRegistryQuery(t *testing.T) {
 			name:     "InvalidValue",
 			value:    "",
 			expected: "",
-			err:      fmt.Errorf("no valid value provided"),
+			err:      fmt.Errorf("invalid ASN value"),
 		},
 		{
 			name:     "ValidAsn",

--- a/pwhois_routeview.go
+++ b/pwhois_routeview.go
@@ -2,7 +2,6 @@ package pwhois
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -41,11 +40,11 @@ args:
 */
 func (server *WhoisServer) FormatRouteViewQuery(asn string) (string, error) {
 
-	if len(asn) == 0 {
-		return "", errors.New("no valid value provided")
+	normalizedASN, err := normalizeASN(asn)
+	if err != nil {
+		return "", err
 	}
-	asn = strings.TrimPrefix(asn, "AS")
-	queryString := fmt.Sprintf("app=\"%s\" routeview source-as=%s\n", AppName, asn)
+	queryString := fmt.Sprintf("app=\"%s\" routeview source-as=%s\n", AppName, normalizedASN)
 	return queryString, nil
 }
 

--- a/pwhois_routeview_test.go
+++ b/pwhois_routeview_test.go
@@ -21,7 +21,7 @@ func TestFormatRouteviewQuery(t *testing.T) {
 			name:     "InvalidValue",
 			value:    "",
 			expected: "",
-			err:      fmt.Errorf("no valid value provided"),
+			err:      fmt.Errorf("invalid ASN value"),
 		},
 		{
 			name:     "ValidAsn",


### PR DESCRIPTION
## Summary

Make ASN query formatting consistent for RouteView, registry, and netblock requests.

## What changed

- add one shared ASN normalizer for decimal values with an optional case-insensitive `AS` prefix
- trim surrounding whitespace before normalizing
- reject empty, prefix-only, spaced-prefix, nonnumeric, and IP-address values consistently
- update all three query formatters to use the same validation and error message
- add a table-driven test matrix that verifies each accepted and rejected form across every formatter

## Impact

All three public formatters now produce the same normalized query for `123`, `AS123`, `as123`, and surrounding whitespace. Invalid values now fail before a request is sent instead of reaching the server through RouteView or registry formatting.

## Validation

- focused formatter tests repeated 20 times
- `go test ./... -count=1 -timeout 30s`
- `go vet ./...`
- `go test -race ./... -count=1 -timeout 45s`
- `go build ./...`
- `git diff --check`

Closes #21
