### PR TITLE
Correct JSON output and postal codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ go test -tags=integration ./...
 
 The live tests depend on the public service's availability, response data, and rate limits, so they are not part of the default GitHub Actions workflow.
 
+## JSON output
+
+The explicit JSON-tagged data records (`WhoIs`, `BGPRoute`, `BGPRoutes`, `RegistryRecord`, `Registry`, `NetblockRecord`, and `Netblock`) use normalized snake_case keys and are covered by serialization tests. Postal codes are text so leading zeros and alphanumeric values are preserved.
+
+`WhoisServer` and the channel response wrappers are connection/control types, not JSON output contracts.
+
 ## License
 
 Licensed under the [MIT License](LICENSE). See `LICENSE` for the copyright and permission notice that must accompany copies or substantial portions of the software.

--- a/pwhois_ip.go
+++ b/pwhois_ip.go
@@ -26,8 +26,8 @@ type WhoIs struct {
 	Region              string    `json:"region"`
 	Country             string    `json:"country"`
 	CountryCode         string    `json:"country_code"`
-	RouteOriginatedDate time.Time `json:"route_orginated_date"`
-	RouteOriginatedTS   int64     `json:"route_orginated_ts"`
+	RouteOriginatedDate time.Time `json:"route_originated_date"`
+	RouteOriginatedTS   int64     `json:"route_originated_ts"`
 }
 
 // Channel return object for ip query response

--- a/pwhois_json_test.go
+++ b/pwhois_json_test.go
@@ -1,0 +1,83 @@
+package pwhois
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestPublicJSONRecordContracts(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		keys  []string
+	}{
+		{
+			name:  "WhoIs",
+			value: WhoIs{},
+			keys: []string{
+				"asn_org_name", "asn_path", "cache_date", "city", "country", "country_code",
+				"ip", "latitude", "longitude", "net_name", "org_name", "origin_asn", "prefix",
+				"region", "route_originated_date", "route_originated_ts",
+			},
+		},
+		{
+			name:  "BGPRoute",
+			value: BGPRoute{},
+			keys:  []string{"as_path", "create_date", "modify_date", "next_hop", "originated_date", "prefix"},
+		},
+		{
+			name:  "BGPRoutes",
+			value: BGPRoutes{},
+			keys:  []string{"asn", "routes"},
+		},
+		{
+			name:  "RegistryRecord",
+			value: RegistryRecord{},
+			keys:  []string{"asn", "registry"},
+		},
+		{
+			name:  "Registry",
+			value: Registry{},
+			keys: []string{
+				"abuse_handle_0", "admin_handle_0", "can_allocate", "city", "comment", "country",
+				"country_code", "create_date", "modify_date", "org_id", "org_name", "org_record", "postal_code",
+				"region", "register_date", "source", "street_1", "tech_handle_0", "update_date",
+			},
+		},
+		{
+			name:  "NetblockRecord",
+			value: NetblockRecord{},
+			keys:  []string{"as", "as_source", "asn", "blocks", "org", "org_id", "org_name", "org_source", "origin_asn"},
+		},
+		{
+			name:  "Netblock",
+			value: Netblock{},
+			keys:  []string{"create_date", "modify_date", "net_name", "net_range", "net_type", "register_date", "source", "update_date"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encoded, err := json.Marshal(test.value)
+			if err != nil {
+				t.Fatalf("marshal %s: %v", test.name, err)
+			}
+
+			var output map[string]json.RawMessage
+			if err := json.Unmarshal(encoded, &output); err != nil {
+				t.Fatalf("decode %s: %v", test.name, err)
+			}
+
+			got := make([]string, 0, len(output))
+			for key := range output {
+				got = append(got, key)
+			}
+			sort.Strings(got)
+			if !reflect.DeepEqual(got, test.keys) {
+				t.Errorf("JSON keys: got %v, want %v", got, test.keys)
+			}
+		})
+	}
+}

--- a/pwhois_netblock.go
+++ b/pwhois_netblock.go
@@ -11,12 +11,12 @@ import (
 // BGP netblock object
 type NetblockRecord struct {
 	Asn       string     `json:"asn"`
-	OriginAs  string     `json:"origin_as"`
+	OriginAs  string     `json:"origin_asn"`
 	ASSource  string     `json:"as_source"`
 	OrgID     string     `json:"org_id"`
 	Org       int64      `json:"org"`
 	AS        int64      `json:"as"`
-	OrgName   string     `json:"org_nam"`
+	OrgName   string     `json:"org_name"`
 	OrgSource string     `json:"org_source"`
 	Netblocks []Netblock `json:"blocks"`
 }

--- a/pwhois_parser_test.go
+++ b/pwhois_parser_test.go
@@ -1,6 +1,7 @@
 package pwhois
 
 import (
+	"encoding/json"
 	"io"
 	"net"
 	"os"
@@ -78,6 +79,7 @@ func TestParseRegistryResponseIsolatesRecords(t *testing.T) {
 	response := strings.Join([]string{
 		"Org-ID: FIRST",
 		"Org-Name: First: Organization",
+		"Postal-Code: 01234",
 		"Can-Allocate: 1",
 		"State: NJ",
 		"Register-Date: 2001-09-18",
@@ -102,11 +104,59 @@ func TestParseRegistryResponseIsolatesRecords(t *testing.T) {
 	if records[0].RegisterDate.IsZero() {
 		t.Fatal("expected ISO register date to be parsed")
 	}
+	if records[0].PostalCode != "01234" {
+		t.Fatalf("postal code: got %q, want %q", records[0].PostalCode, "01234")
+	}
 	if records[1].OrgName != "" {
 		t.Fatalf("second record inherited organization %q", records[1].OrgName)
 	}
 	if records[1].CanAllocate {
 		t.Fatal("expected numeric Can-Allocate value 0 to parse as false")
+	}
+	if records[1].PostalCode != "" {
+		t.Fatalf("second record inherited postal code %q", records[1].PostalCode)
+	}
+}
+
+func TestParseRegistryResponsePreservesAlphanumericPostalCode(t *testing.T) {
+	records, err := parseRegistryResponse("Org-ID: EXAMPLE\nPostal-Code: SW1A 1AA\n")
+	if err != nil {
+		t.Fatalf("parse registry response: %v", err)
+	}
+	if got, want := records[0].PostalCode, "SW1A 1AA"; got != want {
+		t.Fatalf("postal code: got %q, want %q", got, want)
+	}
+}
+
+func TestRegistryPostalCodeJSONIsText(t *testing.T) {
+	tests := []struct {
+		name       string
+		postalCode string
+	}{
+		{name: "leading zero", postalCode: "01234"},
+		{name: "alphanumeric", postalCode: "SW1A 1AA"},
+		{name: "missing", postalCode: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encoded, err := json.Marshal(Registry{PostalCode: test.postalCode})
+			if err != nil {
+				t.Fatalf("marshal registry: %v", err)
+			}
+
+			var output map[string]any
+			if err := json.Unmarshal(encoded, &output); err != nil {
+				t.Fatalf("decode registry JSON: %v", err)
+			}
+			postalCode, ok := output["postal_code"].(string)
+			if !ok {
+				t.Fatalf("postal_code JSON type: got %T, want string", output["postal_code"])
+			}
+			if postalCode != test.postalCode {
+				t.Errorf("postal_code: got %q, want %q", postalCode, test.postalCode)
+			}
+		})
 	}
 }
 

--- a/pwhois_registry.go
+++ b/pwhois_registry.go
@@ -12,7 +12,7 @@ import (
 // ASN registry object
 type RegistryRecord struct {
 	Asn      string   `json:"asn"`
-	Registry Registry `json:"routes"`
+	Registry Registry `json:"registry"`
 }
 
 // Channel return object for registry query response
@@ -29,7 +29,7 @@ type Registry struct {
 	CanAllocate  bool      `json:"can_allocate"`
 	Source       string    `json:"source"`
 	Street1      string    `json:"street_1"`
-	PostalCode   float64   `json:"postal_code"`
+	PostalCode   string    `json:"postal_code"`
 	City         string    `json:"city"`
 	Region       string    `json:"region"`
 	Country      string    `json:"country"`
@@ -41,7 +41,7 @@ type Registry struct {
 	AdminHandle0 string    `json:"admin_handle_0"`
 	AbuseHandle0 string    `json:"abuse_handle_0"`
 	TechHandle0  string    `json:"tech_handle_0"`
-	Comment      string    `json:"comment_handle_0"`
+	Comment      string    `json:"comment"`
 }
 
 /*
@@ -121,6 +121,7 @@ func parseRegistryResponse(response string) ([]Registry, error) {
 		registryParsedStruct.CanAllocate = canAllocate
 		registryParsedStruct.Source = responseMap["Source"]
 		registryParsedStruct.Street1 = responseMap["Street-1"]
+		registryParsedStruct.PostalCode = responseMap["Postal-Code"]
 		registryParsedStruct.City = responseMap["City"]
 		registryParsedStruct.Region = responseMap["Region"]
 		registryParsedStruct.Country = responseMap["Country"]


### PR DESCRIPTION
## Summary

Correct historical JSON field-name mistakes, define the data-record JSON contract with serialization tests, and preserve registry postal codes as text.

## What changed

- correct JSON keys for route-originated fields, netblock origin ASN, netblock organization name, registry nesting, and registry comments
- change `Registry.PostalCode` from `float64` to `string`
- populate postal codes from the server's `Postal-Code` response field
- preserve leading-zero, alphanumeric, and missing postal-code values
- add exact serialized-key snapshots for every explicit JSON-tagged record type
- document which types are JSON output records and which are connection/control types

## Compatibility

This intentionally changes historical v1 JSON keys and the postal-code type. The module has no known adopters, forks, or stars, so correcting these defects now is preferable to preserving them as a long-term public contract.

## Validation

- focused JSON and postal-code tests repeated 20 times
- `go test ./... -count=1 -timeout 30s`
- `go vet ./...`
- `go test -race ./... -count=1 -timeout 45s`
- `go build ./...`
- `git diff --check`

Closes #22
Closes #25
