### PR TITLE
Bound lookup I/O deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go get github.com/georgestarcher/pwhois
 
 ## Usage
 
-Each lookup uses a TCP connection to a PWHOIS server. Close the connection when the lookup is complete. By default, batch IP lookups accept up to 500 addresses; callers should also respect the selected server's rate limits.
+Each lookup uses a TCP connection to a PWHOIS server. Close the connection when the lookup is complete. By default, connection establishment and the complete lookup exchange time out after five seconds; set `WhoisServer.Timeout` to use a different `time.Duration`. Batch IP lookups accept up to 500 addresses; callers should also respect the selected server's rate limits.
 
 ```go
 package main

--- a/pwhois.go
+++ b/pwhois.go
@@ -120,7 +120,10 @@ type WhoisServer struct {
 	Server       string `default:"whois.pwhois.org"`
 	Port         int    `default:"43"`
 	BatchMaxSize int    `default:"500"`
-	Connection   net.Conn
+	// Timeout bounds connection establishment and each lookup's complete I/O
+	// exchange. A zero value uses SocketTimeout.
+	Timeout    time.Duration
+	Connection net.Conn
 }
 
 // Return full DNS server socket Aadress
@@ -156,13 +159,33 @@ func (server *WhoisServer) SetDefaultValues() {
 			// Add cases for other types if needed
 		}
 	}
+
+	if server.Timeout == 0 {
+		server.Timeout = time.Second * time.Duration(SocketTimeout)
+	}
+}
+
+func (server WhoisServer) timeout() time.Duration {
+	if server.Timeout > 0 {
+		return server.Timeout
+	}
+
+	return time.Second * time.Duration(SocketTimeout)
+}
+
+// setLookupDeadline bounds both the request write and response read. PWHOIS
+// lookups use a connection per request, so the deadline covers the complete
+// exchange rather than allowing a server that stops responding to block
+// indefinitely.
+func (server WhoisServer) setLookupDeadline() error {
+	return server.Connection.SetDeadline(time.Now().Add(server.timeout()))
 }
 
 // Establish connection to the pwhois server
 func (server *WhoisServer) Connect() error {
 
 	whoisDialer := &net.Dialer{
-		Timeout:   time.Second * time.Duration(SocketTimeout),
+		Timeout:   server.timeout(),
 		KeepAlive: time.Second * time.Duration(SocketKeepAlive),
 	}
 

--- a/pwhois_deadline_test.go
+++ b/pwhois_deadline_test.go
@@ -1,0 +1,127 @@
+package pwhois
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func connectStalledServer(t *testing.T) net.Conn {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	accepted := make(chan net.Conn, 1)
+	done := make(chan struct{})
+	go func() {
+		connection, err := listener.Accept()
+		if err == nil {
+			accepted <- connection
+			<-done
+			connection.Close()
+		}
+	}()
+
+	connection, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		listener.Close()
+		close(done)
+		t.Fatalf("dial stalled server: %v", err)
+	}
+
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		connection.Close()
+		listener.Close()
+		close(done)
+		t.Fatal("stalled server did not accept connection")
+	}
+
+	t.Cleanup(func() {
+		connection.Close()
+		listener.Close()
+		close(done)
+	})
+
+	return connection
+}
+
+func assertTimeout(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("lookup succeeded against a stalled server")
+	}
+
+	var networkError net.Error
+	if !errors.As(err, &networkError) || !networkError.Timeout() {
+		t.Fatalf("lookup error = %v, want timeout", err)
+	}
+}
+
+func TestLookupDeadlineTimesOutStalledServers(t *testing.T) {
+	const timeout = 25 * time.Millisecond
+
+	tests := []struct {
+		name   string
+		lookup func(WhoisServer) error
+	}{
+		{
+			name: "IP",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan IpLookupResponse, 1)
+				server.LookupIP("8.8.8.8\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name: "RouteView",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan BGPLookupResponse, 1)
+				server.LookupRouteView("3356", "routeview source-as=3356\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name: "Registry",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan RegistryLookupResponse, 1)
+				server.LookupRegistry("3356", "registry source-as=3356\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name: "Netblock",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan NetblockLookupResponse, 1)
+				server.LookupNetblock("3356", "netblock source-as=3356\n", responses)
+				return (<-responses).Error
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := WhoisServer{Connection: connectStalledServer(t), Timeout: timeout}
+			assertTimeout(t, test.lookup(server))
+		})
+	}
+}
+
+func TestWhoisServerTimeoutDefaultsAndOverrides(t *testing.T) {
+	server := new(WhoisServer)
+	server.SetDefaultValues()
+	if got, want := server.Timeout, time.Second*time.Duration(SocketTimeout); got != want {
+		t.Errorf("default timeout = %s, want %s", got, want)
+	}
+
+	server.Timeout = 100 * time.Millisecond
+	if got, want := server.timeout(), 100*time.Millisecond; got != want {
+		t.Errorf("configured timeout = %s, want %s", got, want)
+	}
+}

--- a/pwhois_ip.go
+++ b/pwhois_ip.go
@@ -166,6 +166,10 @@ func (server WhoisServer) LookupIP(query string, c chan IpLookupResponse) {
 		c <- IpLookupResponse{Answer, fmt.Errorf("execute Connect method to establish connection")}
 		return
 	}
+	if err := server.setLookupDeadline(); err != nil {
+		c <- IpLookupResponse{Answer, err}
+		return
+	}
 
 	// Post query to pwhois server
 	address_bytes := []byte(query)

--- a/pwhois_netblock.go
+++ b/pwhois_netblock.go
@@ -218,6 +218,10 @@ func (server WhoisServer) LookupNetblock(asn string, query string, c chan Netblo
 		c <- NetblockLookupResponse{Answer, fmt.Errorf("execute Connect method to establish connection")}
 		return
 	}
+	if err := server.setLookupDeadline(); err != nil {
+		c <- NetblockLookupResponse{Answer, err}
+		return
+	}
 
 	// Post query to pwhois server
 	address_bytes := []byte(query)

--- a/pwhois_registry.go
+++ b/pwhois_registry.go
@@ -175,6 +175,10 @@ func (server WhoisServer) LookupRegistry(asn string, query string, c chan Regist
 		c <- RegistryLookupResponse{Answer, fmt.Errorf("execute Connect method to establish connection")}
 		return
 	}
+	if err := server.setLookupDeadline(); err != nil {
+		c <- RegistryLookupResponse{Answer, err}
+		return
+	}
 
 	// Post query to pwhois server
 	address_bytes := []byte(query)

--- a/pwhois_routeview.go
+++ b/pwhois_routeview.go
@@ -144,6 +144,10 @@ func (server WhoisServer) LookupRouteView(asn string, query string, c chan BGPLo
 		c <- BGPLookupResponse{Answer, fmt.Errorf("execute Connect method to establish connection")}
 		return
 	}
+	if err := server.setLookupDeadline(); err != nil {
+		c <- BGPLookupResponse{Answer, err}
+		return
+	}
 
 	// Post query to pwhois server
 	address_bytes := []byte(query)


### PR DESCRIPTION
## Summary
- Bounds connection establishment and each lookup I/O exchange with a configurable `WhoisServer.Timeout`.
- Applies the deadline consistently to IP, RouteView, Registry, and Netblock lookups.
- Adds deterministic loopback tests for a server that accepts a connection but never responds.

## Why
A reachable PWHOIS server could previously leave a caller blocked indefinitely after accepting a TCP connection. The default remains five seconds, and callers may configure a different `time.Duration`.

Closes #24

## Validation
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
