### PR TITLE
Add AI assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Repository maintainer guide for pwhois
+
+This repository is a Go client and parser for native PWHOIS queries. This file
+is the maintainer contract for automated coding assistants changing this
+repository. It is not consumer integration guidance; assistants adding the
+released module to another application must start with
+[`docs/consumer-agent-guide.md`](docs/consumer-agent-guide.md).
+
+## Scope and contracts
+
+- `pwhois` supports PWHOIS IP, RouteView, registry, and netblock queries.
+  It is not a generic WHOIS, IRR, or RDAP client. Changing only
+  `WhoisServer.Server` does not establish compatibility with another server or
+  response format; add format-specific implementation and tests first.
+- The exported Go API, JSON field names, README, and deterministic tests are
+  consumer-facing contracts. Keep them aligned when behavior changes. Preserve
+  the serialization conventions corrected in #22 and #25 deliberately; see
+  the tracked error and compatibility work in issues #34 and #36.
+- Treat every server response as untrusted. Handle malformed, truncated,
+  delimiter-containing, and oversized values without panics or data loss.
+  Response-size limits are tracked in #32.
+- Do not add library stdout output. Return errors through the documented
+  response types and keep logging, retries, orchestration, and policy in the
+  calling application.
+
+## Network behavior
+
+- A caller owns `WhoisServer.Connection`: call `Connect`, use one connection
+  for one lookup, check the returned response error, and close the connection.
+- `WhoisServer.Timeout` bounds connection establishment and the full lookup
+  write/read exchange. Its zero value uses the five-second default. The current
+  API has no context-aware high-level lookup; do not invent one. See #33 for
+  that future API work.
+- Respect server rate limits. Rate-limit responses and network errors are
+  normal caller-visible outcomes, not conditions to hide with automatic retry.
+
+## Development and test data
+
+- Run `go test ./...`, `go vet ./...`, and `go build ./...` before opening a
+  pull request. Use `go test -race ./...` when changing concurrency or network
+  behavior.
+- Default tests must be deterministic and must not contact public PWHOIS
+  servers. Live checks are opt-in: `go test -tags=integration ./...`.
+- Use reserved and synthetic addresses, ASNs, organizations, and response data
+  in tests and documentation. Never commit live/private registry responses,
+  contact data, credentials, local paths, or rate-limit artifacts.
+
+## Pull requests
+
+- Keep a change focused and update README or documentation whenever a public
+  behavior or contract changes.
+- Make signed commits. Before merge, comment `@codex review`, wait for the
+  completed Codex response, resolve actionable threads, and require green CI.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ func main() {
 
 The other supported lookup types follow the same pattern. Use a separate connected `WhoisServer` for each lookup.
 
+AI coding assistants integrating this module should use the
+[consumer-agent integration guide](docs/consumer-agent-guide.md). Repository
+maintainers should use the [maintainer guide](AGENTS.md).
+
 | Lookup | Query formatter | Lookup method | Response type |
 | --- | --- | --- | --- |
 | IP | `FormatIpQuery` | `LookupIP` | `IpLookupResponse` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# pwhois documentation
+
+The README and Go package documentation are the authoritative references for
+the released API. These guides route readers to the material for their task.
+
+| Audience | Start here | Continue with |
+| --- | --- | --- |
+| Go application developer | [Project README](../README.md) | [Go package documentation](https://pkg.go.dev/github.com/georgestarcher/pwhois) |
+| AI coding assistant integrating the module | [Consumer-agent integration guide](consumer-agent-guide.md) | README usage and the exact version selected in `go.mod` |
+| Repository maintainer | [Maintainer guide](../AGENTS.md) | Deterministic tests and the open repository issues |
+
+## Current validation
+
+Run the default deterministic checks with:
+
+```shell
+go test ./...
+go vet ./...
+go build ./...
+```
+
+Live checks use the public default PWHOIS server and are opt-in:
+
+```shell
+go test -tags=integration ./...
+```
+
+The repository does not yet have a canonical documentation-validation command;
+that work is tracked in issue #28.

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -7,11 +7,18 @@ contract.
 
 ## Install and inspect
 
-Install the exact version the application selects, then inspect its exported
-API before generating code:
+For a new dependency, install an explicit version that the application has
+reviewed. Do not use `@latest` as a substitute for selecting that version:
 
 ```shell
-go get github.com/georgestarcher/pwhois@latest
+go get github.com/georgestarcher/pwhois@v1.0.0
+```
+
+If the application already selects `pwhois` in `go.mod`, do not run `go get`.
+Inspect that selected version and its exported API instead:
+
+```shell
+go list -m -f '{{.Version}}' github.com/georgestarcher/pwhois
 go doc github.com/georgestarcher/pwhois
 ```
 

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -1,0 +1,92 @@
+# Consumer-agent integration guide
+
+This is the self-contained starting guide for an AI coding assistant adding
+`github.com/georgestarcher/pwhois` to another Go application. It is consumer
+guidance, not permission to change this repository or to invent a server
+contract.
+
+## Install and inspect
+
+Install the exact version the application selects, then inspect its exported
+API before generating code:
+
+```shell
+go get github.com/georgestarcher/pwhois@latest
+go doc github.com/georgestarcher/pwhois
+```
+
+Read the selected `go.mod` version and the project README. Do not copy future
+APIs from open issues or assume a generic WHOIS, IRR, or RDAP server accepts
+the PWHOIS query and response format.
+
+## Choose a lookup
+
+| Need | Build a query with | Execute with | Response type |
+| --- | --- | --- | --- |
+| IP or IP batch information | `FormatIpQuery` | `LookupIP` | `IpLookupResponse` |
+| Routing paths for an ASN | `FormatRouteViewQuery` | `LookupRouteView` | `BGPLookupResponse` |
+| Registry data for an ASN | `FormatRegistryQuery` | `LookupRegistry` | `RegistryLookupResponse` |
+| Announced netblocks for an ASN | `FormatNetblockQuery` | `LookupNetblock` | `NetblockLookupResponse` |
+
+Use the query formatter instead of constructing wire text manually. ASN
+formatters accept decimal input with an optional `AS` prefix. The default IP
+batch limit is 500 addresses.
+
+## Connection and error handling
+
+The application owns the TCP connection. Create a `WhoisServer`, set defaults,
+connect, use one connection for one lookup, and close the connection when the
+lookup is complete. Every lookup returns its result through a channel, so use a
+buffered channel and always check `response.Error`.
+
+```go
+server := new(pwhois.WhoisServer)
+server.SetDefaultValues()
+if err := server.Connect(); err != nil {
+	return err
+}
+defer server.Connection.Close()
+
+query, err := server.FormatIpQuery([]string{"192.0.2.1"})
+if err != nil {
+	return err
+}
+
+responses := make(chan pwhois.IpLookupResponse, 1)
+server.LookupIP(query, responses)
+response := <-responses
+if response.Error != nil {
+	return response.Error
+}
+```
+
+`WhoisServer.Timeout` bounds connection establishment and the full request and
+response exchange; its zero value uses the five-second default. Set it to an
+application-appropriate `time.Duration` before calling `Connect` when a
+different bound is required. The current module has no context-aware high-level
+lookup API; that is tracked in issue #33. Response-size bounds are tracked in
+issue #32.
+
+Handle connection, write, read, rate-limit, and parser errors as normal
+application outcomes. Do not silently retry rate-limit errors, share one
+connection among unrelated lookups, or treat a partial result as successful.
+
+## Server and data boundaries
+
+`SetDefaultValues` configures `whois.pwhois.org:43`, the tested default. A
+different hostname alone does not establish compatibility with a generic WHOIS
+or IRR service. Public servers control their availability and rate limits.
+
+Keep credentials, private addresses, live registry responses, contact data,
+and rate-limit details out of source code, committed fixtures, and prompts. Use
+synthetic/reserved documentation values such as `192.0.2.1` in examples.
+
+## Integration checklist
+
+1. Confirm that native PWHOIS is the required protocol and select one lookup.
+2. Inspect the chosen module version and its formatter and response type.
+3. Set an application-appropriate timeout and rate-limit policy.
+4. Close the connection, check every returned error, and test malformed or
+   unavailable-server behavior in the application.
+5. Keep orchestration, retries, logging, credentials, storage, and any action
+   taken from results in application code.


### PR DESCRIPTION
## Summary
- Adds a concise repository-maintainer `AGENTS.md` with API, network, testing, data-handling, and PR rules.
- Adds a documentation index and a self-contained consumer guide for AI-assisted Go integrations.
- Routes README readers to the appropriate maintainer or consumer guide.

## Why
The repository now has tool-neutral guidance for both contributors and external AI-assisted integrations, without promising the context or response-size APIs that remain tracked separately.

Closes #42

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- Verified internal documentation links
