### PR TITLE
Add community health baseline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+
+*.gz binary
+*.zip binary
+*.zlib binary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+Describe the consumer problem and the implemented solution.
+
+## Change type
+
+- [ ] Bug fix
+- [ ] Additive feature
+- [ ] Breaking API change
+- [ ] Documentation or tooling
+- [ ] Dependency update
+
+## Public API and behavior
+
+- [ ] Exported API or JSON changes are intentional and documented.
+- [ ] Connection ownership, cleanup, timeout, and rate-limit behavior were considered.
+- [ ] Untrusted-response handling and response-size impact were considered.
+- [ ] The change does not imply generic WHOIS, IRR, RDAP, or alternative-server compatibility without tests.
+
+## Validation
+
+- [ ] `go test ./...`, `go vet ./...`, and `go build ./...` pass.
+- [ ] `go test -race ./...` passes when concurrency or network behavior changed.
+- [ ] New or changed public behavior has deterministic tests.
+- [ ] README and documentation are updated when needed.
+- [ ] Changelog or release impact is noted for user-facing changes.
+
+## Data and review
+
+- [ ] No live/private PWHOIS responses, registry contacts, credentials, or local paths are included.
+- [ ] Commits are signed, `@codex review` has completed, actionable threads are resolved, and CI is green.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+.DS_Store
+
+# Go build, test, coverage, and profiling outputs.
+*.test
+*.out
+*.prof
+coverage.html
+coverage.out
+bin/
+dist/
+
+# Local PWHOIS response captures may contain registry or contact data.
+testdata/private/
+testdata/live/
+
+# Editor and local environment files.
+.idea/
+.vscode/
+*.swp
+*.swo
+*.tmp

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our commitment
+
+Contributors and maintainers are expected to make participation in this project
+respectful, professional, and free from harassment. This applies regardless of
+experience, identity, background, or role.
+
+## Expected behavior
+
+- Discuss technical decisions with evidence and respect.
+- Accept constructive feedback and correct mistakes openly.
+- Keep issues focused, reproducible, and free of private PWHOIS data.
+- Respect project scope, maintainer time, and review processes.
+
+## Unacceptable behavior
+
+Harassment, discrimination, personal attacks, threats, deliberate disruption,
+or publishing another person's private information are not accepted.
+
+## Enforcement
+
+Maintainers may edit or remove contributions and may temporarily or permanently
+restrict participation when behavior violates this policy. Report abusive
+behavior privately through GitHub's reporting tools or the maintainer's public
+GitHub contact channels. Reports will be reviewed as promptly and
+confidentially as practical.
+
+## Scope
+
+This policy applies in repository discussions, reviews, issues, and other
+public spaces where someone is representing this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+Thanks for improving `pwhois`.
+
+## Scope
+
+`pwhois` is a Go client and parser for native PWHOIS IP, RouteView, registry,
+and netblock queries. It is not a generic WHOIS, IRR, or RDAP client. Keep
+network policy, retries, logging, storage, scheduling, and application actions
+in the consuming application.
+
+## Before opening a pull request
+
+Run the deterministic local checks:
+
+```shell
+go test ./...
+go vet ./...
+go build ./...
+```
+
+Also run `go test -race ./...` for concurrency or network changes. Public
+PWHOIS checks are opt-in and must not become required CI:
+
+```shell
+go test -tags=integration ./...
+```
+
+Use a focused, signed commit. Update the README and relevant documentation for
+public behavior changes. Before merge, comment `@codex review`, wait for the
+completed review, resolve actionable threads, and ensure CI is green.
+
+## Tests and data
+
+Use deterministic loopback tests and synthetic/reserved values. Do not commit
+live PWHOIS responses, organization or contact data, credentials, local paths,
+or rate-limit artifacts. Keep private experiments under ignored paths such as
+`testdata/private/`.
+
+## Public API and release impact
+
+Exported Go symbols, JSON field names, error behavior, and documented network
+contracts are consumer-facing. Preserve them deliberately and call out any
+compatibility or release impact in the pull request. Formal changelog and
+release automation work is tracked in issue #37.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security policy
+
+## Supported version
+
+Security fixes are applied to the current released `v1` line.
+
+## Reporting a vulnerability
+
+Please report security issues privately through GitHub's private vulnerability
+reporting for this repository. Do not open a public issue, publish a proof of
+concept containing live PWHOIS data, or include credentials, contact data, or
+private network information.
+
+Include the affected module version, Go version, a synthetic or minimized
+reproduction, impact, and any relevant configuration. We will acknowledge the
+report and coordinate a fix or disclosure as appropriate.
+
+## Input and network expectations
+
+PWHOIS responses are untrusted network input. The module currently bounds
+connection and lookup I/O time, but applications remain responsible for their
+chosen server, timeout, rate-limit policy, data retention, and how results are
+displayed or acted upon. Response-size limits are tracked in issue #32.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,21 @@
+# Support
+
+## Usage questions
+
+Start with the [README](README.md), [consumer integration guide](docs/consumer-agent-guide.md), and [Go package documentation](https://pkg.go.dev/github.com/georgestarcher/pwhois).
+
+For a question or bug report, include the exact module version, Go version,
+PWHOIS server, lookup type, expected result, actual result, and a minimal
+synthetic reproduction.
+
+## Project scope
+
+This project supports native PWHOIS IP, RouteView, registry, and netblock
+queries. Generic WHOIS, IRR, and RDAP protocols are outside its current scope;
+changing only the server hostname does not make them compatible.
+
+## Sensitive data and security
+
+Do not attach live PWHOIS responses, registry contacts, credentials, private
+addresses, or rate-limit artifacts to public issues. For vulnerabilities, use
+the private process in [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
## Summary
- Completes the remaining community-health baseline with Go-focused ignore, editor, and line-ending rules.
- Adds contributor, security, support, and conduct guidance tailored to native PWHOIS behavior and sensitive response data.
- Adds a pull-request checklist for public API, connection lifecycle, untrusted-response, validation, and review requirements.

## Why
The earlier work already delivered issue forms, deterministic CI, the corrected license link, and maintainer guidance. This PR completes the remaining #27 maintenance surface without changing library behavior.

Closes #27

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- Verified internal documentation links
