### PR TITLE
Bound PWHOIS response sizes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ released module to another application must start with
   the tracked error and compatibility work in issues #34 and #36.
 - Treat every server response as untrusted. Handle malformed, truncated,
   delimiter-containing, and oversized values without panics or data loss.
-  Response-size limits are tracked in #32.
+  All lookups enforce `WhoisServer.MaxResponseBytes`; preserve the shared
+  bounded-reader semantics and the `ErrResponseTooLarge` error contract.
 - Do not add library stdout output. Return errors through the documented
   response types and keep logging, retries, orchestration, and policy in the
   calling application.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go get github.com/georgestarcher/pwhois
 
 ## Usage
 
-Each lookup uses a TCP connection to a PWHOIS server. Close the connection when the lookup is complete. By default, connection establishment and the complete lookup exchange time out after five seconds; set `WhoisServer.Timeout` to use a different `time.Duration`. Batch IP lookups accept up to 500 addresses; callers should also respect the selected server's rate limits.
+Each lookup uses a TCP connection to a PWHOIS server. Close the connection when the lookup is complete. By default, connection establishment and the complete lookup exchange time out after five seconds; set `WhoisServer.Timeout` to use a different `time.Duration`. Responses are limited to 8 MiB by default; set `WhoisServer.MaxResponseBytes` to a positive byte count when an application needs a different bound. Batch IP lookups accept up to 500 addresses; callers should also respect the selected server's rate limits.
 
 ```go
 package main
@@ -63,6 +63,15 @@ func main() {
 ```
 
 The other supported lookup types follow the same pattern. Use a separate connected `WhoisServer` for each lookup.
+
+All four lookup methods enforce the same response-size limit before parsing.
+An over-limit response closes its connection and returns a
+`*pwhois.ResponseTooLargeError`; callers can detect the stable failure class
+with `errors.Is(response.Error, pwhois.ErrResponseTooLarge)`. The error reports
+the configured limit but does not include remote response content. The 8 MiB
+default provides more than 16 KiB per result for a maximum 500-address IP
+batch. RouteView or netblock queries with unusually large legitimate results
+may require a higher application-specific limit.
 
 AI coding assistants integrating this module should use the
 [consumer-agent integration guide](docs/consumer-agent-guide.md). Repository

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -37,7 +37,7 @@ the PWHOIS query and response format.
 
 Use the query formatter instead of constructing wire text manually. ASN
 formatters accept decimal input with an optional `AS` prefix. The default IP
-batch limit is 500 addresses.
+batch limit is 500 addresses. Responses are limited to 8 MiB by default.
 
 ## Connection and error handling
 
@@ -71,8 +71,15 @@ if response.Error != nil {
 response exchange; its zero value uses the five-second default. Set it to an
 application-appropriate `time.Duration` before calling `Connect` when a
 different bound is required. The current module has no context-aware high-level
-lookup API; that is tracked in issue #33. Response-size bounds are tracked in
-issue #32.
+lookup API; that is tracked in issue #33.
+
+`WhoisServer.MaxResponseBytes` bounds response data before parsing. Its zero
+value uses `DefaultMaxResponseBytes` (8 MiB), which provides more than 16 KiB
+per result in a maximum 500-address IP batch. Set a positive application-
+specific value before lookup if unusually large RouteView or netblock results
+are expected. If the limit is exceeded, the lookup closes the connection and
+returns a `*ResponseTooLargeError`. Detect it with
+`errors.Is(err, pwhois.ErrResponseTooLarge)`; do not compare error strings.
 
 Handle connection, write, read, rate-limit, and parser errors as normal
 application outcomes. Do not silently retry rate-limit errors, share one
@@ -92,7 +99,7 @@ synthetic/reserved documentation values such as `192.0.2.1` in examples.
 
 1. Confirm that native PWHOIS is the required protocol and select one lookup.
 2. Inspect the chosen module version and its formatter and response type.
-3. Set an application-appropriate timeout and rate-limit policy.
+3. Set application-appropriate timeout, response-size, and rate-limit policy.
 4. Close the connection, check every returned error, and test malformed or
    unavailable-server behavior in the application.
 5. Keep orchestration, retries, logging, credentials, storage, and any action

--- a/pwhois.go
+++ b/pwhois.go
@@ -3,6 +3,7 @@ package pwhois
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"reflect"
 	"regexp"
@@ -25,6 +26,32 @@ const BatchStart string = "begin\n"
 
 // Query string for ip batch query end
 const BatchEnd string = "end\n"
+
+// DefaultMaxResponseBytes is the maximum response size used when
+// WhoisServer.MaxResponseBytes is zero. Eight MiB provides more than 16 KiB
+// per result in the documented 500-address IP batch while bounding memory
+// consumed by an untrusted PWHOIS server.
+const DefaultMaxResponseBytes int64 = 8 * 1024 * 1024
+
+const responseReadChunkSize = 32 * 1024
+
+// ErrResponseTooLarge identifies a PWHOIS response that exceeded the
+// configured maximum size. Use errors.Is to test lookup errors for this value.
+var ErrResponseTooLarge = errors.New("pwhois response exceeds maximum size")
+
+// ResponseTooLargeError reports the configured response-size limit without
+// retaining or exposing remote response content.
+type ResponseTooLargeError struct {
+	Limit int64
+}
+
+func (err *ResponseTooLargeError) Error() string {
+	return fmt.Sprintf("%s: limit %d bytes", ErrResponseTooLarge, err.Limit)
+}
+
+func (err *ResponseTooLargeError) Unwrap() error {
+	return ErrResponseTooLarge
+}
 
 // Utility function to deduplicate values
 func removeDuplicate[T string | int](sliceList []T) []T {
@@ -122,8 +149,11 @@ type WhoisServer struct {
 	BatchMaxSize int    `default:"500"`
 	// Timeout bounds connection establishment and each lookup's complete I/O
 	// exchange. A zero value uses SocketTimeout.
-	Timeout    time.Duration
-	Connection net.Conn
+	Timeout time.Duration
+	// MaxResponseBytes bounds response data read before parsing. A value less
+	// than or equal to zero uses DefaultMaxResponseBytes.
+	MaxResponseBytes int64
+	Connection       net.Conn
 }
 
 // Return full DNS server socket Aadress
@@ -163,6 +193,9 @@ func (server *WhoisServer) SetDefaultValues() {
 	if server.Timeout == 0 {
 		server.Timeout = time.Second * time.Duration(SocketTimeout)
 	}
+	if server.MaxResponseBytes <= 0 {
+		server.MaxResponseBytes = DefaultMaxResponseBytes
+	}
 }
 
 func (server WhoisServer) timeout() time.Duration {
@@ -179,6 +212,74 @@ func (server WhoisServer) timeout() time.Duration {
 // indefinitely.
 func (server WhoisServer) setLookupDeadline() error {
 	return server.Connection.SetDeadline(time.Now().Add(server.timeout()))
+}
+
+func (server WhoisServer) responseSizeLimit() int64 {
+	if server.MaxResponseBytes > 0 {
+		return server.MaxResponseBytes
+	}
+
+	return DefaultMaxResponseBytes
+}
+
+// readLookupResponse reads remote input into a strictly capacity-controlled
+// raw-response buffer. An over-limit connection is closed because its unread
+// response cannot be safely reused.
+func (server WhoisServer) readLookupResponse() (string, error) {
+	limit := server.responseSizeLimit()
+	response, err := readBoundedResponse(server.Connection, limit)
+	if err != nil {
+		if errors.Is(err, ErrResponseTooLarge) {
+			_ = server.Connection.Close()
+		}
+		return "", err
+	}
+
+	return string(response), nil
+}
+
+func readBoundedResponse(reader io.Reader, limit int64) ([]byte, error) {
+	initialCapacity := responseReadChunkSize
+	if limit < int64(initialCapacity) {
+		initialCapacity = int(limit)
+	}
+	response := make([]byte, 0, initialCapacity)
+	chunk := make([]byte, responseReadChunkSize)
+
+	for {
+		read, err := reader.Read(chunk)
+		if read > 0 {
+			required := len(response) + read
+			if int64(required) > limit {
+				return nil, &ResponseTooLargeError{Limit: limit}
+			}
+
+			if required > cap(response) {
+				nextCapacity := cap(response) * 2
+				if nextCapacity < required {
+					nextCapacity = required
+				}
+				if int64(nextCapacity) > limit {
+					nextCapacity = int(limit)
+				}
+
+				grown := make([]byte, len(response), nextCapacity)
+				copy(grown, response)
+				response = grown
+			}
+
+			originalLength := len(response)
+			response = response[:required]
+			copy(response[originalLength:], chunk[:read])
+		}
+
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return response, nil
+			}
+			return nil, err
+		}
+	}
 }
 
 // Establish connection to the pwhois server

--- a/pwhois_ip.go
+++ b/pwhois_ip.go
@@ -1,10 +1,8 @@
 package pwhois
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"strings"
 	"time"
@@ -180,23 +178,22 @@ func (server WhoisServer) LookupIP(query string, c chan IpLookupResponse) {
 	}
 
 	// Receive query response from pwhois server
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, server.Connection)
+	response, err := server.readLookupResponse()
 	if err != nil {
 		c <- IpLookupResponse{Answer, err}
 		return
 	}
 
 	// Check for daily limit and raise error
-	if strings.Contains(buf.String(), "query limit exceeded") {
+	if strings.Contains(response, "query limit exceeded") {
 		var errString string
-		errString = strings.Replace(buf.String(), "Error: Error: ", errString, 1)
+		errString = strings.Replace(response, "Error: Error: ", errString, 1)
 		c <- IpLookupResponse{Answer, fmt.Errorf("%v", errString)}
 		return
 	}
 	// Parse the query response into our response and return
 	// Answer, err = parseIpResponseBytes(buf.Bytes())
-	Answer, err = parseIpResponse(buf.String())
+	Answer, err = parseIpResponse(response)
 	if err != nil {
 		c <- IpLookupResponse{Answer, err}
 		return

--- a/pwhois_netblock.go
+++ b/pwhois_netblock.go
@@ -1,9 +1,7 @@
 package pwhois
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 )
@@ -232,23 +230,22 @@ func (server WhoisServer) LookupNetblock(asn string, query string, c chan Netblo
 	}
 
 	// Receive query response from pwhois server
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, server.Connection)
+	response, err := server.readLookupResponse()
 	if err != nil {
 		c <- NetblockLookupResponse{Answer, err}
 		return
 	}
 
 	// Check for daily limit and raise error
-	if strings.Contains(buf.String(), "query limit exceeded") {
+	if strings.Contains(response, "query limit exceeded") {
 		var errString string
-		errString = strings.Replace(buf.String(), "Error: Error: ", errString, 1)
+		errString = strings.Replace(response, "Error: Error: ", errString, 1)
 		c <- NetblockLookupResponse{Answer, fmt.Errorf("%v", errString)}
 		return
 	}
 
 	// Parse respose string and return results
-	netblock, err := parseNetblockResponse(asn, buf.String())
+	netblock, err := parseNetblockResponse(asn, response)
 	if err != nil {
 		c <- NetblockLookupResponse{Answer, err}
 		return

--- a/pwhois_registry.go
+++ b/pwhois_registry.go
@@ -1,9 +1,7 @@
 package pwhois
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -189,22 +187,21 @@ func (server WhoisServer) LookupRegistry(asn string, query string, c chan Regist
 	}
 
 	// Receive query response from pwhois server
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, server.Connection)
+	response, err := server.readLookupResponse()
 	if err != nil {
 		c <- RegistryLookupResponse{Answer, err}
 		return
 	}
 
 	// Check for daily limit and raise error
-	if strings.Contains(buf.String(), "query limit exceeded") {
+	if strings.Contains(response, "query limit exceeded") {
 		var errString string
-		errString = strings.Replace(buf.String(), "Error: Error: ", errString, 1)
+		errString = strings.Replace(response, "Error: Error: ", errString, 1)
 		c <- RegistryLookupResponse{Answer, fmt.Errorf("%v", errString)}
 		return
 	}
 
-	registry, err := parseRegistryResponse(buf.String())
+	registry, err := parseRegistryResponse(response)
 	if err != nil {
 		c <- RegistryLookupResponse{Answer, err}
 		return

--- a/pwhois_response_limit_test.go
+++ b/pwhois_response_limit_test.go
@@ -1,0 +1,299 @@
+package pwhois
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+type shortReadConnection struct {
+	net.Conn
+	maximumRead int
+}
+
+func (connection shortReadConnection) Read(buffer []byte) (int, error) {
+	if len(buffer) > connection.maximumRead {
+		buffer = buffer[:connection.maximumRead]
+	}
+	return connection.Conn.Read(buffer)
+}
+
+func connectScriptedResponseServer(t *testing.T, handler func(net.Conn) error) (net.Conn, <-chan error) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer connection.Close()
+		done <- handler(connection)
+	}()
+
+	connection, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		listener.Close()
+		t.Fatalf("dial scripted server: %v", err)
+	}
+
+	t.Cleanup(func() {
+		connection.Close()
+		listener.Close()
+	})
+
+	return connection, done
+}
+
+func waitForScriptedServer(t *testing.T, done <-chan error) {
+	t.Helper()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("scripted server: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("scripted server did not finish")
+	}
+}
+
+func TestReadLookupResponseAcceptsExactLimit(t *testing.T) {
+	const limit = int64(64)
+	payload := strings.Repeat("x", int(limit))
+	connection, done := connectScriptedResponseServer(t, func(connection net.Conn) error {
+		_, err := io.WriteString(connection, payload)
+		return err
+	})
+
+	server := WhoisServer{Connection: connection, MaxResponseBytes: limit}
+	response, err := server.readLookupResponse()
+	if err != nil {
+		t.Fatalf("read exact-limit response: %v", err)
+	}
+	if response != payload {
+		t.Fatalf("response = %q, want %q", response, payload)
+	}
+	waitForScriptedServer(t, done)
+}
+
+func TestReadLookupResponseAcceptsChunkedResponse(t *testing.T) {
+	const limit = int64(64)
+	payload := strings.Repeat("chunked-", 8)
+	connection, done := connectScriptedResponseServer(t, func(connection net.Conn) error {
+		_, err := io.WriteString(connection, payload)
+		return err
+	})
+
+	server := WhoisServer{
+		Connection:       shortReadConnection{Conn: connection, maximumRead: 3},
+		MaxResponseBytes: limit,
+	}
+	response, err := server.readLookupResponse()
+	if err != nil {
+		t.Fatalf("read chunked response: %v", err)
+	}
+	if response != payload {
+		t.Fatalf("response = %q, want %q", response, payload)
+	}
+	waitForScriptedServer(t, done)
+}
+
+func TestAllLookupsAcceptValidResponseAtExactLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		lookup  func(WhoisServer) error
+	}{
+		{
+			name:    "IP",
+			payload: "IP: 192.0.2.1",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan IpLookupResponse, 1)
+				server.LookupIP("192.0.2.1\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name: "RouteView",
+			payload: strings.Join([]string{
+				"Origin-AS: 64500",
+				"*> 192.0.2.0/24 | Jul 18 2026 00:00:04 | Jul 18 2026 00:00:04 | May 28 2026 06:56:01 | 192.0.2.254 | 64501 64500",
+			}, "\n"),
+			lookup: func(server WhoisServer) error {
+				responses := make(chan BGPLookupResponse, 1)
+				server.LookupRouteView("64500", "routeview source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name:    "Registry",
+			payload: "Org-ID: EXAMPLE\nOrg-Name: Example Organization",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan RegistryLookupResponse, 1)
+				server.LookupRegistry("64500", "registry source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name: "Netblock",
+			payload: strings.Join([]string{
+				"Origin-AS: 64500",
+				"AS: 0",
+				"Org: 0",
+				"Org-Name: Example Networks",
+				"*> 192.0.2.0 - 192.0.2.255 | EXAMPLE-NET | reassignment | 2019-05-25 | 2019-09-25 | Jun 28 2019 16:53:01 | Jul 18 2026 03:19:32 | TEST",
+			}, "\n"),
+			lookup: func(server WhoisServer) error {
+				responses := make(chan NetblockLookupResponse, 1)
+				server.LookupNetblock("64500", "netblock source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			connection, done := connectScriptedResponseServer(t, func(connection net.Conn) error {
+				if _, err := bufio.NewReader(connection).ReadString('\n'); err != nil {
+					return err
+				}
+				_, err := io.WriteString(connection, test.payload)
+				return err
+			})
+
+			server := WhoisServer{
+				Connection:       connection,
+				MaxResponseBytes: int64(len(test.payload)),
+			}
+			if err := test.lookup(server); err != nil {
+				t.Fatalf("exact-limit lookup: %v", err)
+			}
+			waitForScriptedServer(t, done)
+		})
+	}
+}
+
+func TestAllLookupsRejectOneByteOverLimit(t *testing.T) {
+	const limit = int64(64)
+	payload := strings.Repeat("s", int(limit+1))
+
+	tests := []struct {
+		name   string
+		lookup func(WhoisServer) error
+	}{
+		{
+			name: "IP",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan IpLookupResponse, 1)
+				server.LookupIP("192.0.2.1\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name: "RouteView",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan BGPLookupResponse, 1)
+				server.LookupRouteView("64500", "routeview source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name: "Registry",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan RegistryLookupResponse, 1)
+				server.LookupRegistry("64500", "registry source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name: "Netblock",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan NetblockLookupResponse, 1)
+				server.LookupNetblock("64500", "netblock source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			connection, done := connectScriptedResponseServer(t, func(connection net.Conn) error {
+				if _, err := io.WriteString(connection, payload); err != nil {
+					return err
+				}
+				if err := connection.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+					return err
+				}
+				_, err := io.Copy(io.Discard, connection)
+				return err
+			})
+
+			server := WhoisServer{Connection: connection, MaxResponseBytes: limit}
+			err := test.lookup(server)
+			if !errors.Is(err, ErrResponseTooLarge) {
+				t.Fatalf("lookup error = %v, want ErrResponseTooLarge", err)
+			}
+
+			var sizeError *ResponseTooLargeError
+			if !errors.As(err, &sizeError) {
+				t.Fatalf("lookup error type = %T, want *ResponseTooLargeError", err)
+			}
+			if sizeError.Limit != limit {
+				t.Errorf("error limit = %d, want %d", sizeError.Limit, limit)
+			}
+			if strings.Contains(err.Error(), payload) {
+				t.Error("size error exposed remote response content")
+			}
+
+			waitForScriptedServer(t, done)
+		})
+	}
+}
+
+func TestReadLookupResponseStopsNeverEndingResponseAtLimit(t *testing.T) {
+	const limit = int64(128)
+	connection, done := connectScriptedResponseServer(t, func(connection net.Conn) error {
+		if err := connection.SetWriteDeadline(time.Now().Add(time.Second)); err != nil {
+			return err
+		}
+		chunk := []byte(strings.Repeat("n", 32))
+		for {
+			if _, err := connection.Write(chunk); err != nil {
+				return nil
+			}
+		}
+	})
+
+	server := WhoisServer{Connection: connection, MaxResponseBytes: limit}
+	started := time.Now()
+	_, err := server.readLookupResponse()
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("read never-ending response error = %v, want ErrResponseTooLarge", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("over-limit response took %s to terminate", elapsed)
+	}
+	waitForScriptedServer(t, done)
+}
+
+func TestResponseTooLargeErrorContract(t *testing.T) {
+	err := &ResponseTooLargeError{Limit: 1234}
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatal("ResponseTooLargeError does not unwrap to ErrResponseTooLarge")
+	}
+	if got, want := err.Error(), fmt.Sprintf("%s: limit 1234 bytes", ErrResponseTooLarge); got != want {
+		t.Errorf("error text = %q, want %q", got, want)
+	}
+}

--- a/pwhois_routeview.go
+++ b/pwhois_routeview.go
@@ -1,9 +1,7 @@
 package pwhois
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -158,22 +156,21 @@ func (server WhoisServer) LookupRouteView(asn string, query string, c chan BGPLo
 	}
 
 	// Receive query response from pwhois server
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, server.Connection)
+	response, err := server.readLookupResponse()
 	if err != nil {
 		c <- BGPLookupResponse{Answer, err}
 		return
 	}
 
 	// Check for daily limit and raise error
-	if strings.Contains(buf.String(), "query limit exceeded") {
+	if strings.Contains(response, "query limit exceeded") {
 		var errString string
-		errString = strings.Replace(buf.String(), "Error: Error: ", errString, 1)
+		errString = strings.Replace(response, "Error: Error: ", errString, 1)
 		c <- BGPLookupResponse{Answer, fmt.Errorf("%v", errString)}
 		return
 	}
 
-	routes, err := parseBgpResponse(buf.String())
+	routes, err := parseBgpResponse(response)
 	Answer.Asn = asn
 	Answer.Routes = routes
 

--- a/pwhois_test.go
+++ b/pwhois_test.go
@@ -31,6 +31,11 @@ func TestSetDefaultValues(t *testing.T) {
 			got:      fmt.Sprintf("%v", server.BatchMaxSize),
 			expected: "500",
 		},
+		{
+			name:     "MaxResponseBytes",
+			got:      fmt.Sprintf("%v", server.MaxResponseBytes),
+			expected: fmt.Sprintf("%v", DefaultMaxResponseBytes),
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

- add an 8 MiB default response-size limit with an explicit `WhoisServer.MaxResponseBytes` override
- enforce the same capacity-controlled reader across IP, RouteView, registry, and netblock lookups
- expose `ErrResponseTooLarge` and `ResponseTooLargeError` for stable `errors.Is`/`errors.As` handling
- close over-limit connections without retaining or exposing remote response content
- document batch sizing and unusually large RouteView/netblock responses

## Root cause

Every lookup copied the entire remote response into an unbounded buffer. A remote server could therefore consume arbitrary client memory even though lookup deadlines bounded elapsed time.

## Validation

- `go test -race ./...`
- `go test -count=20 ./...`
- `go vet ./...`
- `go build ./...`

The loopback TCP tests cover all four lookup types at the exact limit and one byte over it, fragmented reads, never-ending responses, typed error matching, and connection cleanup.

Closes #32