### PR TITLE
Define stable lookup errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,13 @@ released module to another application must start with
   response format; add format-specific implementation and tests first.
 - The exported Go API, JSON field names, README, and deterministic tests are
   consumer-facing contracts. Keep them aligned when behavior changes. Preserve
-  the serialization conventions corrected in #22 and #25 deliberately; see
-  the tracked error and compatibility work in issues #34 and #36.
+  the serialization conventions corrected in #22 and #25 deliberately; use
+  the stable error taxonomy and `OperationError` contract from #34, and see
+  issue #36 for compatibility work.
 - Treat every server response as untrusted. Handle malformed, truncated,
   delimiter-containing, and oversized values without panics or data loss.
   All lookups enforce `WhoisServer.MaxResponseBytes`; preserve the shared
-  bounded-reader semantics and the `ErrResponseTooLarge` error contract.
+  bounded-reader semantics and the stable error contract.
 - Do not add library stdout output. Return errors through the documented
   response types and keep logging, retries, orchestration, and policy in the
   calling application.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,5 +41,7 @@ or rate-limit artifacts. Keep private experiments under ignored paths such as
 
 Exported Go symbols, JSON field names, error behavior, and documented network
 contracts are consumer-facing. Preserve them deliberately and call out any
-compatibility or release impact in the pull request. Formal changelog and
-release automation work is tracked in issue #37.
+compatibility or release impact in the pull request. Stable error sentinels and
+typed error metadata require `errors.Is`/`errors.As` compatibility tests and a
+release-impact note in the pull request. Formal changelog and release
+automation work is tracked in issue #37.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Each lookup uses a TCP connection to a PWHOIS server. Close the connection when 
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
@@ -53,6 +54,13 @@ func main() {
 	response := <-responses
 
 	if response.Error != nil {
+		if errors.Is(response.Error, pwhois.ErrRateLimited) {
+			// Apply the calling application's rate-limit policy.
+		}
+		var operationError *pwhois.OperationError
+		if errors.As(response.Error, &operationError) {
+			log.Printf("%s against %s failed", operationError.Operation, operationError.Server)
+		}
 		log.Fatal(response.Error)
 	}
 
@@ -72,6 +80,30 @@ the configured limit but does not include remote response content. The 8 MiB
 default provides more than 16 KiB per result for a maximum 500-address IP
 batch. RouteView or netblock queries with unusually large legitimate results
 may require a higher application-specific limit.
+
+## Error handling
+
+Every formatter, `Connect`, and lookup response error uses a stable class that
+can be tested with `errors.Is`; error wording is not an API contract.
+
+| Error class | Meaning |
+| --- | --- |
+| `ErrInvalidInput` | A query formatter rejected caller input. |
+| `ErrConnection` | The connection is absent or a network operation failed. |
+| `ErrTimeout` / `ErrCanceled` | The lookup deadline expired or its connection reported cancellation. |
+| `ErrRateLimited` | The PWHOIS server reported its query limit. |
+| `ErrResponseTooLarge` | The response exceeded `MaxResponseBytes`. |
+| `ErrMalformedResponse` | A non-empty response could not be parsed safely. |
+| `ErrNoRecords` | The server returned no records for the lookup. |
+
+`Connect` and lookup methods wrap failures in `*pwhois.OperationError`, which
+contains the operation and configured endpoint while preserving the stable
+class and underlying transport/parser error. Use `errors.As` only when that
+additional context is useful, as shown in the example above.
+
+Rate-limit and remote parser failures never include the full server response
+in the returned error. `*pwhois.ResponseTooLargeError` additionally reports
+the configured byte limit.
 
 AI coding assistants integrating this module should use the
 [consumer-agent integration guide](docs/consumer-agent-guide.md). Repository

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -81,6 +81,14 @@ are expected. If the limit is exceeded, the lookup closes the connection and
 returns a `*ResponseTooLargeError`. Detect it with
 `errors.Is(err, pwhois.ErrResponseTooLarge)`; do not compare error strings.
 
+Use `errors.Is` to classify every failure: `ErrInvalidInput`, `ErrConnection`,
+`ErrTimeout`, `ErrCanceled`, `ErrRateLimited`, `ErrResponseTooLarge`,
+`ErrMalformedResponse`, and `ErrNoRecords`. `Connect` and lookup failures are
+wrapped in `*OperationError`, so `errors.As` can retrieve the operation and
+configured endpoint without losing the underlying transport or parser cause.
+Do not compare error strings or expose full server response content in calling
+application logs.
+
 Handle connection, write, read, rate-limit, and parser errors as normal
 application outcomes. Do not silently retry rate-limit errors, share one
 connection among unrelated lookups, or treat a partial result as successful.
@@ -100,7 +108,7 @@ synthetic/reserved documentation values such as `192.0.2.1` in examples.
 1. Confirm that native PWHOIS is the required protocol and select one lookup.
 2. Inspect the chosen module version and its formatter and response type.
 3. Set application-appropriate timeout, response-size, and rate-limit policy.
-4. Close the connection, check every returned error, and test malformed or
-   unavailable-server behavior in the application.
+4. Close the connection, classify every returned error with `errors.Is`, and
+   test malformed or unavailable-server behavior in the application.
 5. Keep orchestration, retries, logging, credentials, storage, and any action
    taken from results in application code.

--- a/pwhois.go
+++ b/pwhois.go
@@ -1,6 +1,7 @@
 package pwhois
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -35,13 +36,47 @@ const DefaultMaxResponseBytes int64 = 8 * 1024 * 1024
 
 const responseReadChunkSize = 32 * 1024
 
-// ErrResponseTooLarge identifies a PWHOIS response that exceeded the
-// configured maximum size. Use errors.Is to test lookup errors for this value.
-var ErrResponseTooLarge = errors.New("pwhois response exceeds maximum size")
+// Stable error classes returned by this package. Use errors.Is to branch on a
+// class and errors.As to retrieve OperationError or ResponseTooLargeError
+// metadata without comparing error strings.
+var (
+	ErrInvalidInput      = errors.New("pwhois invalid input")
+	ErrConnection        = errors.New("pwhois connection failure")
+	ErrTimeout           = errors.New("pwhois lookup timed out")
+	ErrCanceled          = errors.New("pwhois lookup canceled")
+	ErrRateLimited       = errors.New("pwhois server rate limit exceeded")
+	ErrResponseTooLarge  = errors.New("pwhois response exceeds maximum size")
+	ErrMalformedResponse = errors.New("pwhois malformed response")
+	ErrNoRecords         = errors.New("pwhois no records returned")
+)
+
+// OperationError adds lookup operation and server context while preserving the
+// stable error class and the underlying cause through errors.Is and errors.As.
+type OperationError struct {
+	// Operation identifies the attempted action, such as "lookup IP" or
+	// "connect".
+	Operation string
+	// Server is the configured PWHOIS endpoint when one was supplied.
+	Server string
+	// Err is the classified error and optional underlying cause.
+	Err error
+}
+
+func (err *OperationError) Error() string {
+	if err.Server == "" {
+		return fmt.Sprintf("pwhois %s: %v", err.Operation, err.Err)
+	}
+	return fmt.Sprintf("pwhois %s against %s: %v", err.Operation, err.Server, err.Err)
+}
+
+func (err *OperationError) Unwrap() error {
+	return err.Err
+}
 
 // ResponseTooLargeError reports the configured response-size limit without
 // retaining or exposing remote response content.
 type ResponseTooLargeError struct {
+	// Limit is the configured maximum response size in bytes.
 	Limit int64
 }
 
@@ -51,6 +86,38 @@ func (err *ResponseTooLargeError) Error() string {
 
 func (err *ResponseTooLargeError) Unwrap() error {
 	return ErrResponseTooLarge
+}
+
+func invalidInputError(description string) error {
+	return fmt.Errorf("%w: %s", ErrInvalidInput, description)
+}
+
+func noRecordsError(resource string) error {
+	return fmt.Errorf("%w: %s", ErrNoRecords, resource)
+}
+
+func malformedResponseError(err error) error {
+	if errors.Is(err, ErrNoRecords) || errors.Is(err, ErrMalformedResponse) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", ErrMalformedResponse, err)
+}
+
+type responseValueError struct {
+	field string
+	err   error
+}
+
+func (err *responseValueError) Error() string {
+	return fmt.Sprintf("invalid %s value", err.field)
+}
+
+func (err *responseValueError) Unwrap() error {
+	return err.err
+}
+
+func invalidResponseValue(field string, err error) error {
+	return &responseValueError{field: field, err: err}
 }
 
 // Utility function to deduplicate values
@@ -80,7 +147,7 @@ func normalizeASN(value string) (string, error) {
 		asn = asn[2:]
 	}
 	if !isOnlyDigits(asn) {
-		return "", errors.New("invalid ASN value")
+		return "", invalidInputError("ASN must be decimal digits with an optional AS prefix")
 	}
 
 	return asn, nil
@@ -108,14 +175,16 @@ func parseResponseTime(field, value string, layouts ...string) (time.Time, error
 		return time.Time{}, nil
 	}
 
+	var parseError error
 	for _, layout := range layouts {
 		parsed, err := time.Parse(layout, value)
 		if err == nil {
 			return parsed, nil
 		}
+		parseError = err
 	}
 
-	return time.Time{}, fmt.Errorf("invalid %s value", field)
+	return time.Time{}, invalidResponseValue(field, parseError)
 }
 
 func parseResponseInt64(field, value string) (int64, error) {
@@ -125,7 +194,7 @@ func parseResponseInt64(field, value string) (int64, error) {
 
 	parsed, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid %s value: %w", field, err)
+		return 0, invalidResponseValue(field, err)
 	}
 	return parsed, nil
 }
@@ -137,7 +206,7 @@ func parseResponseFloat64(field, value string) (float64, error) {
 
 	parsed, err := strconv.ParseFloat(value, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid %s value: %w", field, err)
+		return 0, invalidResponseValue(field, err)
 	}
 	return parsed, nil
 }
@@ -212,6 +281,61 @@ func (server WhoisServer) timeout() time.Duration {
 // indefinitely.
 func (server WhoisServer) setLookupDeadline() error {
 	return server.Connection.SetDeadline(time.Now().Add(server.timeout()))
+}
+
+func (server WhoisServer) operationError(operation string, err error) error {
+	endpoint := ""
+	if server.Server != "" && server.Port != 0 {
+		endpoint = server.ServerAddressString()
+	}
+	return &OperationError{Operation: operation, Server: endpoint, Err: err}
+}
+
+func classifyTransportError(err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return fmt.Errorf("%w: %w", ErrCanceled, err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("%w: %w", ErrTimeout, err)
+	}
+
+	var networkError net.Error
+	if errors.As(err, &networkError) && networkError.Timeout() {
+		return fmt.Errorf("%w: %w", ErrTimeout, err)
+	}
+
+	return fmt.Errorf("%w: %w", ErrConnection, err)
+}
+
+func isRateLimitedResponse(response string) bool {
+	return strings.Contains(strings.ToLower(response), "query limit exceeded")
+}
+
+// executeQuery applies one consistent connection, deadline, transport, and
+// rate-limit error contract to every native PWHOIS lookup.
+func (server WhoisServer) executeQuery(operation, query string) (string, error) {
+	if server.Connection == nil {
+		return "", server.operationError(operation, ErrConnection)
+	}
+	if err := server.setLookupDeadline(); err != nil {
+		return "", server.operationError(operation, classifyTransportError(err))
+	}
+	if _, err := server.Connection.Write([]byte(query)); err != nil {
+		return "", server.operationError(operation, classifyTransportError(err))
+	}
+
+	response, err := server.readLookupResponse()
+	if err != nil {
+		if errors.Is(err, ErrResponseTooLarge) {
+			return "", server.operationError(operation, err)
+		}
+		return "", server.operationError(operation, classifyTransportError(err))
+	}
+	if isRateLimitedResponse(response) {
+		return "", server.operationError(operation, ErrRateLimited)
+	}
+
+	return response, nil
 }
 
 func (server WhoisServer) responseSizeLimit() int64 {
@@ -293,7 +417,7 @@ func (server *WhoisServer) Connect() error {
 	var err error
 	server.Connection, err = whoisDialer.Dial("tcp", server.ServerAddressString())
 	if err != nil {
-		return err
+		return server.operationError("connect", classifyTransportError(err))
 	}
 	return nil
 }

--- a/pwhois_deadline_test.go
+++ b/pwhois_deadline_test.go
@@ -57,6 +57,9 @@ func assertTimeout(t *testing.T, err error) {
 	if err == nil {
 		t.Fatal("lookup succeeded against a stalled server")
 	}
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("lookup error = %v, want ErrTimeout", err)
+	}
 
 	var networkError net.Error
 	if !errors.As(err, &networkError) || !networkError.Timeout() {

--- a/pwhois_error_example_test.go
+++ b/pwhois_error_example_test.go
@@ -1,0 +1,24 @@
+package pwhois
+
+import (
+	"errors"
+	"fmt"
+)
+
+func ExampleOperationError() {
+	err := &OperationError{
+		Operation: "lookup IP",
+		Server:    "whois.pwhois.org:43",
+		Err:       ErrRateLimited,
+	}
+
+	fmt.Println(errors.Is(err, ErrRateLimited))
+	var operationError *OperationError
+	fmt.Println(errors.As(err, &operationError))
+	fmt.Printf("%s %s\n", operationError.Operation, operationError.Server)
+
+	// Output:
+	// true
+	// true
+	// lookup IP whois.pwhois.org:43
+}

--- a/pwhois_error_test.go
+++ b/pwhois_error_test.go
@@ -1,0 +1,234 @@
+package pwhois
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type deadlineErrorConnection struct {
+	net.Conn
+	err error
+}
+
+func (connection deadlineErrorConnection) SetDeadline(time.Time) error {
+	return connection.err
+}
+
+func lookupErrorCases() []struct {
+	name      string
+	operation string
+	lookup    func(WhoisServer) error
+} {
+	return []struct {
+		name      string
+		operation string
+		lookup    func(WhoisServer) error
+	}{
+		{
+			name:      "IP",
+			operation: "lookup IP",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan IpLookupResponse, 1)
+				server.LookupIP("192.0.2.1\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name:      "RouteView",
+			operation: "lookup RouteView",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan BGPLookupResponse, 1)
+				server.LookupRouteView("64500", "routeview source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name:      "Registry",
+			operation: "lookup registry",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan RegistryLookupResponse, 1)
+				server.LookupRegistry("64500", "registry source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name:      "Netblock",
+			operation: "lookup netblock",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan NetblockLookupResponse, 1)
+				server.LookupNetblock("64500", "netblock source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+	}
+}
+
+func assertOperationError(t *testing.T, err error, operation string) {
+	t.Helper()
+
+	var operationError *OperationError
+	if !errors.As(err, &operationError) {
+		t.Fatalf("error type = %T, want *OperationError", err)
+	}
+	if operationError.Operation != operation {
+		t.Errorf("operation = %q, want %q", operationError.Operation, operation)
+	}
+	if operationError.Server != "test.pwhois.example:43" {
+		t.Errorf("server = %q, want test.pwhois.example:43", operationError.Server)
+	}
+}
+
+func lookupErrorFromResponse(t *testing.T, lookup func(WhoisServer) error, response string, maximumResponseBytes int64) error {
+	t.Helper()
+
+	connection, done := connectScriptedResponseServer(t, func(connection net.Conn) error {
+		if _, err := bufio.NewReader(connection).ReadString('\n'); err != nil {
+			return err
+		}
+		_, err := io.WriteString(connection, response)
+		return err
+	})
+
+	server := WhoisServer{
+		Server:           "test.pwhois.example",
+		Port:             43,
+		Connection:       connection,
+		MaxResponseBytes: maximumResponseBytes,
+	}
+	err := lookup(server)
+	waitForScriptedServer(t, done)
+	return err
+}
+
+func TestLookupErrorClassesAreConsistent(t *testing.T) {
+	secret := "do-not-return-this-server-response"
+	malformedResponses := map[string]string{
+		"IP":        "IP 192.0.2.1",
+		"RouteView": "*> too short",
+		"Registry":  "Org-ID EXAMPLE",
+		"Netblock":  "Origin-AS: 64500",
+	}
+
+	for _, lookupCase := range lookupErrorCases() {
+		t.Run(lookupCase.name+"/not connected", func(t *testing.T) {
+			err := lookupCase.lookup(WhoisServer{Server: "test.pwhois.example", Port: 43})
+			if !errors.Is(err, ErrConnection) {
+				t.Fatalf("error = %v, want ErrConnection", err)
+			}
+			assertOperationError(t, err, lookupCase.operation)
+		})
+
+		t.Run(lookupCase.name+"/rate limited", func(t *testing.T) {
+			err := lookupErrorFromResponse(t, lookupCase.lookup, "Error: query limit exceeded\n"+secret, 0)
+			if !errors.Is(err, ErrRateLimited) {
+				t.Fatalf("error = %v, want ErrRateLimited", err)
+			}
+			if strings.Contains(err.Error(), secret) {
+				t.Fatal("rate-limit error exposed remote response content")
+			}
+			assertOperationError(t, err, lookupCase.operation)
+		})
+
+		t.Run(lookupCase.name+"/no records", func(t *testing.T) {
+			err := lookupErrorFromResponse(t, lookupCase.lookup, "", 0)
+			if !errors.Is(err, ErrNoRecords) {
+				t.Fatalf("error = %v, want ErrNoRecords", err)
+			}
+			assertOperationError(t, err, lookupCase.operation)
+		})
+
+		t.Run(lookupCase.name+"/malformed response", func(t *testing.T) {
+			err := lookupErrorFromResponse(t, lookupCase.lookup, malformedResponses[lookupCase.name], 0)
+			if !errors.Is(err, ErrMalformedResponse) {
+				t.Fatalf("error = %v, want ErrMalformedResponse", err)
+			}
+			assertOperationError(t, err, lookupCase.operation)
+		})
+	}
+}
+
+func TestLookupCancellationErrorPreservesClass(t *testing.T) {
+	client, peer := net.Pipe()
+	defer client.Close()
+	defer peer.Close()
+
+	server := WhoisServer{
+		Server:     "test.pwhois.example",
+		Port:       43,
+		Connection: deadlineErrorConnection{Conn: client, err: context.Canceled},
+	}
+	responses := make(chan IpLookupResponse, 1)
+	server.LookupIP("192.0.2.1\n", responses)
+	err := (<-responses).Error
+	if !errors.Is(err, ErrCanceled) || !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want ErrCanceled and context.Canceled", err)
+	}
+	assertOperationError(t, err, "lookup IP")
+}
+
+func TestConnectErrorPreservesTransportCause(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	address := listener.Addr().(*net.TCPAddr)
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	server := WhoisServer{Server: "127.0.0.1", Port: address.Port, Timeout: time.Second}
+	err = server.Connect()
+	if !errors.Is(err, ErrConnection) {
+		t.Fatalf("connect error = %v, want ErrConnection", err)
+	}
+	var operationError *OperationError
+	if !errors.As(err, &operationError) || operationError.Operation != "connect" {
+		t.Fatalf("connect error = %v, want connect OperationError", err)
+	}
+	var networkError *net.OpError
+	if !errors.As(err, &networkError) {
+		t.Fatalf("connect error = %v, want wrapped *net.OpError", err)
+	}
+}
+
+func TestMalformedResponsePreservesParserCause(t *testing.T) {
+	secret := "untrusted-field-value"
+	_, err := parseIpResponse("IP: 192.0.2.1\nLatitude: " + secret)
+	if !errors.Is(err, ErrMalformedResponse) {
+		t.Fatalf("parse error = %v, want ErrMalformedResponse", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatal("parse error exposed an untrusted response value")
+	}
+	var numberError *strconv.NumError
+	if !errors.As(err, &numberError) {
+		t.Fatalf("parse error = %v, want wrapped *strconv.NumError", err)
+	}
+}
+
+func TestNetblockServerErrorDoesNotExposeRemoteContent(t *testing.T) {
+	secret := "untrusted-server-detail"
+	_, err := parseNetblockResponse("64500", "Error: "+secret)
+	if !errors.Is(err, ErrNoRecords) {
+		t.Fatalf("parse error = %v, want ErrNoRecords", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatal("netblock error exposed remote response content")
+	}
+}
+
+func TestResponseTooLargeIncludesOperationContext(t *testing.T) {
+	lookupCase := lookupErrorCases()[0]
+	err := lookupErrorFromResponse(t, lookupCase.lookup, strings.Repeat("x", 65), 64)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("error = %v, want ErrResponseTooLarge", err)
+	}
+	assertOperationError(t, err, lookupCase.operation)
+}

--- a/pwhois_ip.go
+++ b/pwhois_ip.go
@@ -1,7 +1,6 @@
 package pwhois
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -58,9 +57,9 @@ func (server *WhoisServer) FormatIpQuery(values []string) (string, error) {
 
 	// check slice sizes and build query string
 	if len(deduplicatedValues) == 0 {
-		return "", errors.New("no valid values provided")
+		return "", invalidInputError("at least one valid IP address is required")
 	} else if len(deduplicatedValues) > server.BatchMaxSize {
-		return "", fmt.Errorf("values slice larger than maximum: %v", server.BatchMaxSize)
+		return "", invalidInputError(fmt.Sprintf("IP batch exceeds maximum of %d addresses", server.BatchMaxSize))
 	} else if len(deduplicatedValues) == 1 {
 		queryString = queryString + fmt.Sprintf("%s\n", deduplicatedValues[0])
 		return queryString, nil
@@ -73,8 +72,16 @@ func (server *WhoisServer) FormatIpQuery(values []string) (string, error) {
 	return queryString, nil
 }
 
-// Parse response string into slice of WhoIs records
+// Parse response string into slice of WhoIs records.
 func parseIpResponse(response string) ([]WhoIs, error) {
+	records, err := parseIPResponseData(response)
+	if err != nil {
+		return nil, malformedResponseError(err)
+	}
+	return records, nil
+}
+
+func parseIPResponseData(response string) ([]WhoIs, error) {
 
 	var responseWhoIs []WhoIs
 	responseRecords := strings.Split(response, "\n\n")
@@ -82,7 +89,7 @@ func parseIpResponse(response string) ([]WhoIs, error) {
 	// Break the records apart and into the WhoIs structs
 	// One record will be returned as a slice of one WhoIs member
 	if len(response) == 0 || len(responseRecords) == 0 {
-		return nil, fmt.Errorf("no records returned")
+		return nil, noRecordsError("IP lookup")
 	}
 	for recordIndex, record := range responseRecords {
 		if len(record) == 0 {
@@ -143,6 +150,9 @@ func parseIpResponse(response string) ([]WhoIs, error) {
 		whoIsParsedStruct.RouteOriginatedTS = routeOriginatedTS
 		responseWhoIs = append(responseWhoIs, whoIsParsedStruct)
 	}
+	if len(responseWhoIs) == 0 {
+		return nil, noRecordsError("IP lookup")
+	}
 	return responseWhoIs, nil
 }
 
@@ -159,43 +169,16 @@ func (server WhoisServer) LookupIP(query string, c chan IpLookupResponse) {
 
 	var Answer []WhoIs
 
-	// Check for pwhois server connection
-	if server.Connection == nil {
-		c <- IpLookupResponse{Answer, fmt.Errorf("execute Connect method to establish connection")}
-		return
-	}
-	if err := server.setLookupDeadline(); err != nil {
-		c <- IpLookupResponse{Answer, err}
-		return
-	}
-
-	// Post query to pwhois server
-	address_bytes := []byte(query)
-	_, err := server.Connection.Write(address_bytes)
+	response, err := server.executeQuery("lookup IP", query)
 	if err != nil {
 		c <- IpLookupResponse{Answer, err}
 		return
 	}
 
-	// Receive query response from pwhois server
-	response, err := server.readLookupResponse()
-	if err != nil {
-		c <- IpLookupResponse{Answer, err}
-		return
-	}
-
-	// Check for daily limit and raise error
-	if strings.Contains(response, "query limit exceeded") {
-		var errString string
-		errString = strings.Replace(response, "Error: Error: ", errString, 1)
-		c <- IpLookupResponse{Answer, fmt.Errorf("%v", errString)}
-		return
-	}
 	// Parse the query response into our response and return
-	// Answer, err = parseIpResponseBytes(buf.Bytes())
 	Answer, err = parseIpResponse(response)
 	if err != nil {
-		c <- IpLookupResponse{Answer, err}
+		c <- IpLookupResponse{Answer, server.operationError("lookup IP", err)}
 		return
 	}
 	c <- IpLookupResponse{Answer, nil}

--- a/pwhois_ip_test.go
+++ b/pwhois_ip_test.go
@@ -2,7 +2,7 @@ package pwhois
 
 import (
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"math/rand"
 	"net"
 	"testing"
@@ -42,7 +42,7 @@ func TestFormatIpQuery(t *testing.T) {
 			name:     "InvalidSingleValue",
 			values:   []string{"dolly.bean"},
 			expected: "",
-			err:      fmt.Errorf("no valid values provided"),
+			err:      ErrInvalidInput,
 		},
 		{
 			name:     "SingleIpValue",
@@ -60,7 +60,7 @@ func TestFormatIpQuery(t *testing.T) {
 			name:     "OverMaxValues",
 			values:   overCapactitySlice,
 			expected: "",
-			err:      fmt.Errorf("values slice larger than maximum: %v", server.BatchMaxSize),
+			err:      ErrInvalidInput,
 		},
 	}
 
@@ -68,11 +68,9 @@ func TestFormatIpQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			got, err := server.FormatIpQuery(c.values)
 			if c.err != nil {
-				t.Log(c.err)
-				if fmt.Sprintf("%v", err) != fmt.Sprintf("%v", c.err) {
-					t.Errorf("Expected %v, got %v", c.err, err)
+				if !errors.Is(err, c.err) {
+					t.Errorf("error = %v, want errors.Is(..., %v)", err, c.err)
 				}
-				t.Logf("%v", err)
 			}
 
 			if got != c.expected {

--- a/pwhois_netblock.go
+++ b/pwhois_netblock.go
@@ -63,7 +63,7 @@ func getNetblockSections(response string) ([]string, []string, error) {
 
 	// Check for empty response
 	if len(response) == 0 {
-		return nil, nil, fmt.Errorf("no records returned")
+		return nil, nil, noRecordsError("netblock lookup")
 	}
 
 	lines := strings.Split(response, "\n")
@@ -85,7 +85,7 @@ func getNetblockSections(response string) ([]string, []string, error) {
 	// Example `Error: No netblock found in registry database for org-id=UAAB`s`
 	for _, line := range header {
 		if strings.HasPrefix(line, "Error: ") {
-			return header, blocks, fmt.Errorf("%s", strings.TrimPrefix(line, "Error: "))
+			return header, blocks, noRecordsError("netblock lookup")
 		}
 	}
 	return header, blocks, nil
@@ -94,7 +94,14 @@ func getNetblockSections(response string) ([]string, []string, error) {
 
 // Parse response string into slice of WhoIs records
 func parseNetblockResponse(asn string, response string) ([]NetblockRecord, error) {
+	records, err := parseNetblockResponseData(asn, response)
+	if err != nil {
+		return nil, malformedResponseError(err)
+	}
+	return records, nil
+}
 
+func parseNetblockResponseData(asn string, response string) ([]NetblockRecord, error) {
 	var responseNetblockRecords []NetblockRecord
 	var responseRecord NetblockRecord
 	var blocks []Netblock
@@ -103,7 +110,7 @@ func parseNetblockResponse(asn string, response string) ([]NetblockRecord, error
 	//responseMap := make(map[string]string)
 
 	if len(response) == 0 {
-		return nil, fmt.Errorf("no records returned")
+		return nil, noRecordsError("netblock lookup")
 	}
 
 	headerStrings, blockStrings, err := getNetblockSections(response)
@@ -211,47 +218,20 @@ func (server WhoisServer) LookupNetblock(asn string, query string, c chan Netblo
 
 	var Answer NetblockRecord
 
-	// Check for pwhois server connection
-	if server.Connection == nil {
-		c <- NetblockLookupResponse{Answer, fmt.Errorf("execute Connect method to establish connection")}
-		return
-	}
-	if err := server.setLookupDeadline(); err != nil {
-		c <- NetblockLookupResponse{Answer, err}
-		return
-	}
-
-	// Post query to pwhois server
-	address_bytes := []byte(query)
-	_, err := server.Connection.Write(address_bytes)
+	response, err := server.executeQuery("lookup netblock", query)
 	if err != nil {
 		c <- NetblockLookupResponse{Answer, err}
-		return
-	}
-
-	// Receive query response from pwhois server
-	response, err := server.readLookupResponse()
-	if err != nil {
-		c <- NetblockLookupResponse{Answer, err}
-		return
-	}
-
-	// Check for daily limit and raise error
-	if strings.Contains(response, "query limit exceeded") {
-		var errString string
-		errString = strings.Replace(response, "Error: Error: ", errString, 1)
-		c <- NetblockLookupResponse{Answer, fmt.Errorf("%v", errString)}
 		return
 	}
 
 	// Parse respose string and return results
 	netblock, err := parseNetblockResponse(asn, response)
 	if err != nil {
-		c <- NetblockLookupResponse{Answer, err}
+		c <- NetblockLookupResponse{Answer, server.operationError("lookup netblock", err)}
 		return
 	}
 	if len(netblock) == 0 {
-		c <- NetblockLookupResponse{Answer, fmt.Errorf("no records returned")}
+		c <- NetblockLookupResponse{Answer, server.operationError("lookup netblock", noRecordsError("netblock lookup"))}
 		return
 	}
 

--- a/pwhois_netblock_test.go
+++ b/pwhois_netblock_test.go
@@ -1,7 +1,7 @@
 package pwhois
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 )
 
@@ -21,13 +21,13 @@ func TestFormatNetblockQuery(t *testing.T) {
 			name:     "EmptyValue",
 			value:    "",
 			expected: "",
-			err:      fmt.Errorf("invalid ASN value"),
+			err:      ErrInvalidInput,
 		},
 		{
 			name:     "InvalidValue",
 			value:    "8.8.8.8",
 			expected: "",
-			err:      fmt.Errorf("invalid ASN value"),
+			err:      ErrInvalidInput,
 		},
 		{
 			name:     "ValidValue",
@@ -41,11 +41,9 @@ func TestFormatNetblockQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			got, err := server.FormatNetblockQuery(c.value)
 			if c.err != nil {
-				t.Log(c.err)
-				if fmt.Sprintf("%v", err) != fmt.Sprintf("%v", c.err) {
-					t.Errorf("Expected %v, got %v", c.err, err)
+				if !errors.Is(err, c.err) {
+					t.Errorf("error = %v, want errors.Is(..., %v)", err, c.err)
 				}
-				t.Logf("%v", err)
 			}
 
 			if got != c.expected {

--- a/pwhois_registry.go
+++ b/pwhois_registry.go
@@ -62,14 +62,21 @@ func (server *WhoisServer) FormatRegistryQuery(asn string) (string, error) {
 
 // Parse response string into slice of WhoIs records
 func parseRegistryResponse(response string) ([]Registry, error) {
+	records, err := parseRegistryResponseData(response)
+	if err != nil {
+		return nil, malformedResponseError(err)
+	}
+	return records, nil
+}
 
+func parseRegistryResponseData(response string) ([]Registry, error) {
 	var responseRegistry []Registry
 	responseRecords := strings.Split(response, "\n\n")
 
 	// Break the records apart and into the WhoIs structs
 	// One record will be returned as a slice of one WhoIs member
 	if len(response) == 0 || len(responseRecords) == 0 {
-		return nil, fmt.Errorf("no records returned")
+		return nil, noRecordsError("registry lookup")
 	}
 	for recordIndex, record := range responseRecords {
 		if len(record) == 0 {
@@ -135,6 +142,9 @@ func parseRegistryResponse(response string) ([]Registry, error) {
 
 		responseRegistry = append(responseRegistry, registryParsedStruct)
 	}
+	if len(responseRegistry) == 0 {
+		return nil, noRecordsError("registry lookup")
+	}
 	return responseRegistry, nil
 }
 
@@ -147,7 +157,7 @@ func parseCanAllocate(value string) (bool, error) {
 	default:
 		parsed, err := strconv.ParseBool(value)
 		if err != nil {
-			return false, fmt.Errorf("invalid Can-Allocate value: %w", err)
+			return false, invalidResponseValue("Can-Allocate", err)
 		}
 		return parsed, nil
 	}
@@ -168,46 +178,19 @@ func (server WhoisServer) LookupRegistry(asn string, query string, c chan Regist
 
 	var Answer RegistryRecord
 
-	// Check for pwhois server connection
-	if server.Connection == nil {
-		c <- RegistryLookupResponse{Answer, fmt.Errorf("execute Connect method to establish connection")}
-		return
-	}
-	if err := server.setLookupDeadline(); err != nil {
-		c <- RegistryLookupResponse{Answer, err}
-		return
-	}
-
-	// Post query to pwhois server
-	address_bytes := []byte(query)
-	_, err := server.Connection.Write(address_bytes)
+	response, err := server.executeQuery("lookup registry", query)
 	if err != nil {
 		c <- RegistryLookupResponse{Answer, err}
-		return
-	}
-
-	// Receive query response from pwhois server
-	response, err := server.readLookupResponse()
-	if err != nil {
-		c <- RegistryLookupResponse{Answer, err}
-		return
-	}
-
-	// Check for daily limit and raise error
-	if strings.Contains(response, "query limit exceeded") {
-		var errString string
-		errString = strings.Replace(response, "Error: Error: ", errString, 1)
-		c <- RegistryLookupResponse{Answer, fmt.Errorf("%v", errString)}
 		return
 	}
 
 	registry, err := parseRegistryResponse(response)
 	if err != nil {
-		c <- RegistryLookupResponse{Answer, err}
+		c <- RegistryLookupResponse{Answer, server.operationError("lookup registry", err)}
 		return
 	}
 	if len(registry) == 0 {
-		c <- RegistryLookupResponse{Answer, fmt.Errorf("no records returned")}
+		c <- RegistryLookupResponse{Answer, server.operationError("lookup registry", noRecordsError("registry lookup"))}
 		return
 	}
 

--- a/pwhois_registry_test.go
+++ b/pwhois_registry_test.go
@@ -1,7 +1,7 @@
 package pwhois
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 )
 
@@ -21,7 +21,7 @@ func TestFormatRegistryQuery(t *testing.T) {
 			name:     "InvalidValue",
 			value:    "",
 			expected: "",
-			err:      fmt.Errorf("invalid ASN value"),
+			err:      ErrInvalidInput,
 		},
 		{
 			name:     "ValidAsn",
@@ -35,11 +35,9 @@ func TestFormatRegistryQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			got, err := server.FormatRegistryQuery(c.value)
 			if c.err != nil {
-				t.Log(c.err)
-				if fmt.Sprintf("%v", err) != fmt.Sprintf("%v", c.err) {
-					t.Errorf("Expected %v, got %v", c.err, err)
+				if !errors.Is(err, c.err) {
+					t.Errorf("error = %v, want errors.Is(..., %v)", err, c.err)
 				}
-				t.Logf("%v", err)
 			}
 
 			if got != c.expected {

--- a/pwhois_routeview.go
+++ b/pwhois_routeview.go
@@ -48,16 +48,23 @@ func (server *WhoisServer) FormatRouteViewQuery(asn string) (string, error) {
 
 // Parse response string into slice of BGP routing records
 func parseBgpResponse(response string) ([]BGPRoute, error) {
-	if len(response) == 0 {
-		return nil, fmt.Errorf("no records returned")
+	routes, err := parseBGPResponseData(response)
+	if err != nil {
+		return nil, malformedResponseError(err)
+	}
+	return routes, nil
+}
 
+func parseBGPResponseData(response string) ([]BGPRoute, error) {
+	if len(response) == 0 {
+		return nil, noRecordsError("RouteView lookup")
 	}
 	routes, err := parseBGPData(response)
 	if err != nil {
 		return nil, err
 	}
 	if len(routes) == 0 {
-		return nil, fmt.Errorf("no routes returned")
+		return nil, noRecordsError("RouteView lookup")
 	}
 	return routes, nil
 }
@@ -115,7 +122,7 @@ func parseASPath(asPathFields []string) ([]int, error) {
 	for index, asStr := range asPathFields {
 		as, err := strconv.Atoi(asStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid AS path value at position %d: %w", index+1, err)
+			return nil, invalidResponseValue(fmt.Sprintf("AS path value at position %d", index+1), err)
 		}
 		asPath = append(asPath, as)
 	}
@@ -137,36 +144,9 @@ func (server WhoisServer) LookupRouteView(asn string, query string, c chan BGPLo
 
 	var Answer BGPRoutes
 
-	// Check for pwhois server connection
-	if server.Connection == nil {
-		c <- BGPLookupResponse{Answer, fmt.Errorf("execute Connect method to establish connection")}
-		return
-	}
-	if err := server.setLookupDeadline(); err != nil {
-		c <- BGPLookupResponse{Answer, err}
-		return
-	}
-
-	// Post query to pwhois server
-	address_bytes := []byte(query)
-	_, err := server.Connection.Write(address_bytes)
+	response, err := server.executeQuery("lookup RouteView", query)
 	if err != nil {
 		c <- BGPLookupResponse{Answer, err}
-		return
-	}
-
-	// Receive query response from pwhois server
-	response, err := server.readLookupResponse()
-	if err != nil {
-		c <- BGPLookupResponse{Answer, err}
-		return
-	}
-
-	// Check for daily limit and raise error
-	if strings.Contains(response, "query limit exceeded") {
-		var errString string
-		errString = strings.Replace(response, "Error: Error: ", errString, 1)
-		c <- BGPLookupResponse{Answer, fmt.Errorf("%v", errString)}
 		return
 	}
 
@@ -175,7 +155,7 @@ func (server WhoisServer) LookupRouteView(asn string, query string, c chan BGPLo
 	Answer.Routes = routes
 
 	if err != nil {
-		c <- BGPLookupResponse{Answer, err}
+		c <- BGPLookupResponse{Answer, server.operationError("lookup RouteView", err)}
 		return
 	}
 

--- a/pwhois_routeview_test.go
+++ b/pwhois_routeview_test.go
@@ -1,7 +1,7 @@
 package pwhois
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 )
 
@@ -21,7 +21,7 @@ func TestFormatRouteviewQuery(t *testing.T) {
 			name:     "InvalidValue",
 			value:    "",
 			expected: "",
-			err:      fmt.Errorf("invalid ASN value"),
+			err:      ErrInvalidInput,
 		},
 		{
 			name:     "ValidAsn",
@@ -35,11 +35,9 @@ func TestFormatRouteviewQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			got, err := server.FormatRouteViewQuery(c.value)
 			if c.err != nil {
-				t.Log(c.err)
-				if fmt.Sprintf("%v", err) != fmt.Sprintf("%v", c.err) {
-					t.Errorf("Expected %v, got %v", c.err, err)
+				if !errors.Is(err, c.err) {
+					t.Errorf("error = %v, want errors.Is(..., %v)", err, c.err)
 				}
-				t.Logf("%v", err)
 			}
 
 			if got != c.expected {


### PR DESCRIPTION
## Summary

- add a documented sentinel taxonomy for invalid input, connection, timeout/cancellation, rate limiting, response size, malformed responses, and no records
- add `OperationError` context while preserving stable classes and native transport/parser causes through `errors.Is` and `errors.As`
- centralize the four lookup methods' connection, deadline, write, read, and rate-limit behavior
- prevent server-response and malformed field content from appearing in returned errors
- document consumer handling and add package/example and loopback compatibility tests

## Root cause

Lookup methods and parsers returned ad hoc formatted errors. Callers had to compare strings, and rate-limit or parser errors could expose uncontrolled remote text.

## Release impact

Error text is no longer a supported compatibility surface. Consumers should use the documented sentinels with `errors.Is` and `OperationError` / `ResponseTooLargeError` with `errors.As`.

## Validation

- `go test ./...`
- `go test -count=20 ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`

The deterministic loopback suite verifies all four lookup types for connection, rate-limit, no-record, malformed-response, and response-limit outcomes, plus timeout/cancellation and preserved transport/parser causes.

Closes #34