### PR TITLE
Add source-aware cache contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,30 @@ Rate-limit and remote parser failures never include the full server response
 in the returned error. `*pwhois.ResponseTooLargeError` additionally reports
 the configured byte limit.
 
+## Cache foundation
+
+The module includes a source-aware cache contract for applications that build
+context-aware lookup orchestration. `CacheCoordinator` supports bypass,
+read-through, forced refresh, fresh-only, and bounded stale-if-error policies.
+It also coalesces concurrent misses for one canonical key within a process.
+
+The coordinator does **not** change the connection ownership or automatically
+wrap the four existing lookup methods. A calling application supplies a
+context-aware fetch function, a `Cache` backend, and an explicit
+`SourceCachePolicy` for every provider/source. This lets a later high-level
+lookup API use the same contract without making the current channel-based API
+silently retry or cache network operations.
+
+Cache keys include the source, endpoint, protocol, normalized query, options,
+parser version, and result schema version. Stored `CacheEnvelope` values
+contain bounded normalized JSON, timestamps, provider error class, and
+provenance; there is no raw-response field. `MemoryCache` is available for
+process-local use. File, gateway, and Redis implementations can satisfy the
+same `Cache` interface without changing lookup policy.
+
+See the [cache contract guide](docs/cache-contract.md) for policy semantics,
+error handling, and an integration example.
+
 AI coding assistants integrating this module should use the
 [consumer-agent integration guide](docs/consumer-agent-guide.md). Repository
 maintainers should use the [maintainer guide](AGENTS.md).

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,775 @@
+package pwhois
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// CacheEnvelopeVersion identifies the on-disk/wire representation used by
+	// cache backends. Backends must preserve this value with each entry.
+	CacheEnvelopeVersion = 1
+	cacheKeyVersion      = 1
+)
+
+// Stable cache error classes. Cache errors are deliberately separate from
+// provider errors so a backend failure cannot be mistaken for a PWHOIS result.
+var (
+	ErrCacheMiss          = errors.New("pwhois cache miss")
+	ErrCacheStale         = errors.New("pwhois cache entry is stale")
+	ErrCacheUnavailable   = errors.New("pwhois cache unavailable")
+	ErrInvalidCacheEntry  = errors.New("pwhois invalid cache entry")
+	ErrCacheEntryTooLarge = errors.New("pwhois cache entry exceeds maximum size")
+)
+
+// CacheError adds the failed cache operation and canonical key while
+// preserving its stable class through errors.Is and errors.As.
+type CacheError struct {
+	Operation string
+	Key       string
+	Err       error
+}
+
+func (err *CacheError) Error() string {
+	if err.Key == "" {
+		return fmt.Sprintf("pwhois cache %s: %v", err.Operation, err.Err)
+	}
+	return fmt.Sprintf("pwhois cache %s for %s: %v", err.Operation, err.Key, err.Err)
+}
+
+func (err *CacheError) Unwrap() error {
+	return err.Err
+}
+
+// CacheEntryTooLargeError reports the configured cache-entry limit without
+// retaining or exposing the normalized result.
+type CacheEntryTooLargeError struct {
+	Limit int64
+}
+
+func (err *CacheEntryTooLargeError) Error() string {
+	return fmt.Sprintf("%s: limit %d bytes", ErrCacheEntryTooLarge, err.Limit)
+}
+
+func (err *CacheEntryTooLargeError) Unwrap() error {
+	return ErrCacheEntryTooLarge
+}
+
+// Cache is the storage contract implemented by in-memory, file, gateway, or
+// Redis-backed caches. Get reports a miss with found=false, not ErrCacheMiss.
+// Backend failures are returned as errors and classified by CacheCoordinator.
+type Cache interface {
+	Get(ctx context.Context, key string) (entry CacheEnvelope, found bool, err error)
+	Set(ctx context.Context, key string, entry CacheEnvelope) error
+	Delete(ctx context.Context, key string) error
+}
+
+// CacheClock allows deterministic expiry and stale-window tests.
+type CacheClock interface {
+	Now() time.Time
+}
+
+type systemCacheClock struct{}
+
+func (systemCacheClock) Now() time.Time { return time.Now() }
+
+// CacheKeySpec contains every value that can change the meaning or shape of a
+// normalized result. NormalizedQuery must already be in the provider-specific
+// canonical form chosen by the caller.
+type CacheKeySpec struct {
+	Source              string
+	Endpoint            string
+	Protocol            string
+	NormalizedQuery     string
+	Options             map[string]string
+	ParserVersion       string
+	ResultSchemaVersion string
+}
+
+type cacheKeyOption struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type canonicalCacheKey struct {
+	Version             int              `json:"version"`
+	Source              string           `json:"source"`
+	Endpoint            string           `json:"endpoint"`
+	Protocol            string           `json:"protocol"`
+	NormalizedQuery     string           `json:"normalized_query"`
+	Options             []cacheKeyOption `json:"options"`
+	ParserVersion       string           `json:"parser_version"`
+	ResultSchemaVersion string           `json:"result_schema_version"`
+}
+
+func normalizeCacheKeySpec(spec CacheKeySpec) (CacheKeySpec, error) {
+	spec.Source = strings.ToLower(strings.TrimSpace(spec.Source))
+	spec.Endpoint = strings.ToLower(strings.TrimSpace(spec.Endpoint))
+	spec.Protocol = strings.ToLower(strings.TrimSpace(spec.Protocol))
+	spec.NormalizedQuery = strings.TrimSpace(spec.NormalizedQuery)
+	spec.ParserVersion = strings.TrimSpace(spec.ParserVersion)
+	spec.ResultSchemaVersion = strings.TrimSpace(spec.ResultSchemaVersion)
+
+	switch {
+	case spec.Source == "":
+		return CacheKeySpec{}, invalidInputError("cache source is required")
+	case spec.Endpoint == "":
+		return CacheKeySpec{}, invalidInputError("cache endpoint is required")
+	case spec.Protocol == "":
+		return CacheKeySpec{}, invalidInputError("cache protocol is required")
+	case spec.NormalizedQuery == "":
+		return CacheKeySpec{}, invalidInputError("normalized cache query is required")
+	case spec.ParserVersion == "":
+		return CacheKeySpec{}, invalidInputError("cache parser version is required")
+	case spec.ResultSchemaVersion == "":
+		return CacheKeySpec{}, invalidInputError("cache result schema version is required")
+	}
+
+	return spec, nil
+}
+
+// CanonicalCacheKey returns a deterministic, source-aware cache key. The
+// digest prevents delimiter ambiguity while the prefix makes the key format
+// and source recognizable to cache operators.
+func CanonicalCacheKey(spec CacheKeySpec) (string, error) {
+	normalized, err := normalizeCacheKeySpec(spec)
+	if err != nil {
+		return "", err
+	}
+
+	optionNames := make([]string, 0, len(normalized.Options))
+	for name := range normalized.Options {
+		optionNames = append(optionNames, name)
+	}
+	sort.Strings(optionNames)
+
+	options := make([]cacheKeyOption, 0, len(optionNames))
+	for _, name := range optionNames {
+		options = append(options, cacheKeyOption{Name: name, Value: normalized.Options[name]})
+	}
+
+	payload, err := json.Marshal(canonicalCacheKey{
+		Version:             cacheKeyVersion,
+		Source:              normalized.Source,
+		Endpoint:            normalized.Endpoint,
+		Protocol:            normalized.Protocol,
+		NormalizedQuery:     normalized.NormalizedQuery,
+		Options:             options,
+		ParserVersion:       normalized.ParserVersion,
+		ResultSchemaVersion: normalized.ResultSchemaVersion,
+	})
+	if err != nil {
+		return "", fmt.Errorf("build canonical cache key: %w", err)
+	}
+
+	digest := sha256.Sum256(payload)
+	return fmt.Sprintf("pwhois-cache:v%d:%s:%s", cacheKeyVersion, normalized.Source, hex.EncodeToString(digest[:])), nil
+}
+
+// ProviderErrorClass is the serializable form of a stable provider error.
+// It records only the class, never error text or remote response content.
+type ProviderErrorClass string
+
+const (
+	ProviderErrorNone              ProviderErrorClass = ""
+	ProviderErrorInvalidInput      ProviderErrorClass = "invalid_input"
+	ProviderErrorConnection        ProviderErrorClass = "connection"
+	ProviderErrorTimeout           ProviderErrorClass = "timeout"
+	ProviderErrorCanceled          ProviderErrorClass = "canceled"
+	ProviderErrorRateLimited       ProviderErrorClass = "rate_limited"
+	ProviderErrorResponseTooLarge  ProviderErrorClass = "response_too_large"
+	ProviderErrorMalformedResponse ProviderErrorClass = "malformed_response"
+	ProviderErrorNoRecords         ProviderErrorClass = "no_records"
+	ProviderErrorUnknown           ProviderErrorClass = "unknown"
+)
+
+// ClassifyProviderError converts a provider error into a stable serializable
+// class. Unknown errors remain visibly unknown and are never negative-cached.
+func ClassifyProviderError(err error) ProviderErrorClass {
+	if err == nil {
+		return ProviderErrorNone
+	}
+
+	switch {
+	case errors.Is(err, ErrInvalidInput):
+		return ProviderErrorInvalidInput
+	case errors.Is(err, ErrConnection):
+		return ProviderErrorConnection
+	case errors.Is(err, ErrTimeout), errors.Is(err, context.DeadlineExceeded):
+		return ProviderErrorTimeout
+	case errors.Is(err, ErrCanceled), errors.Is(err, context.Canceled):
+		return ProviderErrorCanceled
+	case errors.Is(err, ErrRateLimited):
+		return ProviderErrorRateLimited
+	case errors.Is(err, ErrResponseTooLarge):
+		return ProviderErrorResponseTooLarge
+	case errors.Is(err, ErrMalformedResponse):
+		return ProviderErrorMalformedResponse
+	case errors.Is(err, ErrNoRecords):
+		return ProviderErrorNoRecords
+	default:
+		return ProviderErrorUnknown
+	}
+}
+
+func providerErrorSentinel(class ProviderErrorClass) error {
+	switch class {
+	case ProviderErrorInvalidInput:
+		return ErrInvalidInput
+	case ProviderErrorConnection:
+		return ErrConnection
+	case ProviderErrorTimeout:
+		return ErrTimeout
+	case ProviderErrorCanceled:
+		return ErrCanceled
+	case ProviderErrorRateLimited:
+		return ErrRateLimited
+	case ProviderErrorResponseTooLarge:
+		return ErrResponseTooLarge
+	case ProviderErrorMalformedResponse:
+		return ErrMalformedResponse
+	case ProviderErrorNoRecords:
+		return ErrNoRecords
+	default:
+		return nil
+	}
+}
+
+// CachedProviderError reports a provider failure reconstructed from a cached
+// negative or rate-limit entry. errors.Is continues to match the stable class.
+type CachedProviderError struct {
+	Class     ProviderErrorClass
+	Source    string
+	FetchedAt time.Time
+}
+
+func (err *CachedProviderError) Error() string {
+	return fmt.Sprintf("cached %s provider result from %s at %s", err.Class, err.Source, err.FetchedAt.Format(time.RFC3339))
+}
+
+func (err *CachedProviderError) Unwrap() error {
+	return providerErrorSentinel(err.Class)
+}
+
+// CacheProvenance identifies where a normalized result came from. Details
+// should contain non-sensitive provider metadata, never raw response content.
+type CacheProvenance struct {
+	Provider string            `json:"provider"`
+	Endpoint string            `json:"endpoint"`
+	Protocol string            `json:"protocol"`
+	Details  map[string]string `json:"details,omitempty"`
+}
+
+// CacheEnvelope is the versioned value stored by a Cache implementation.
+// NormalizedResult is parsed, bounded JSON; the contract has no raw-response
+// field so backends do not retain provider payloads by default.
+type CacheEnvelope struct {
+	Version             int                `json:"version"`
+	Key                 string             `json:"key"`
+	Source              string             `json:"source"`
+	Endpoint            string             `json:"endpoint"`
+	Protocol            string             `json:"protocol"`
+	NormalizedQuery     string             `json:"normalized_query"`
+	ParserVersion       string             `json:"parser_version"`
+	FetchedAt           time.Time          `json:"fetched_at"`
+	ExpiresAt           time.Time          `json:"expires_at"`
+	ResultSchemaVersion string             `json:"result_schema_version"`
+	NormalizedResult    json.RawMessage    `json:"normalized_result,omitempty"`
+	ProviderErrorClass  ProviderErrorClass `json:"provider_error_class,omitempty"`
+	Provenance          CacheProvenance    `json:"provenance"`
+}
+
+// CachePolicy controls whether a lookup may read, refresh, or bypass cache.
+type CachePolicy string
+
+const (
+	CachePolicyBypass       CachePolicy = "bypass"
+	CachePolicyReadThrough  CachePolicy = "read-through"
+	CachePolicyRefresh      CachePolicy = "refresh"
+	CachePolicyFreshOnly    CachePolicy = "fresh-only"
+	CachePolicyStaleIfError CachePolicy = "stale-if-error"
+)
+
+func (policy CachePolicy) valid() bool {
+	switch policy {
+	case CachePolicyBypass, CachePolicyReadThrough, CachePolicyRefresh, CachePolicyFreshOnly, CachePolicyStaleIfError:
+		return true
+	default:
+		return false
+	}
+}
+
+// SourceCachePolicy gives each provider/source its own success, negative,
+// rate-limit, and bounded-staleness lifetimes. A zero negative or rate-limit
+// TTL disables caching for that class.
+type SourceCachePolicy struct {
+	SuccessTTL     time.Duration
+	NoRecordsTTL   time.Duration
+	RateLimitedTTL time.Duration
+	MaxStale       time.Duration
+}
+
+func (policy SourceCachePolicy) validate(source string) error {
+	if policy.SuccessTTL <= 0 {
+		return invalidInputError(fmt.Sprintf("cache source %q requires a positive success TTL", source))
+	}
+	if policy.NoRecordsTTL < 0 || policy.RateLimitedTTL < 0 || policy.MaxStale < 0 {
+		return invalidInputError(fmt.Sprintf("cache source %q TTLs cannot be negative", source))
+	}
+	return nil
+}
+
+// CacheRequest combines the canonical key inputs with the desired cache
+// behavior. It does not perform a network lookup itself.
+type CacheRequest struct {
+	Key    CacheKeySpec
+	Policy CachePolicy
+}
+
+// CacheFetchResult is returned by a caller-supplied provider function. Only a
+// normalized JSON result and provenance can enter the cache envelope.
+type CacheFetchResult struct {
+	NormalizedResult json.RawMessage
+	Provenance       CacheProvenance
+}
+
+// CacheFetchFunc performs one context-aware provider operation for Lookup.
+type CacheFetchFunc func(context.Context) (CacheFetchResult, error)
+
+// CacheState describes where CacheLookupResult came from.
+type CacheState string
+
+const (
+	CacheStateBypassed  CacheState = "bypassed"
+	CacheStateHit       CacheState = "hit"
+	CacheStateRefreshed CacheState = "refreshed"
+	CacheStateProvider  CacheState = "provider"
+	CacheStateStale     CacheState = "stale"
+)
+
+// CacheLookupResult makes cache and fallback behavior explicit. CacheError is
+// set when a provider result remains usable despite a backend read/write
+// failure. RefreshErrorClass is set when stale-if-error returned bounded stale
+// data after a failed provider refresh.
+type CacheLookupResult struct {
+	Envelope          CacheEnvelope
+	State             CacheState
+	CacheHit          bool
+	Stale             bool
+	Coalesced         bool
+	CacheError        error
+	RefreshErrorClass ProviderErrorClass
+}
+
+// CacheCoordinatorConfig configures source-aware cache orchestration.
+type CacheCoordinatorConfig struct {
+	Cache          Cache
+	Clock          CacheClock
+	SourcePolicies map[string]SourceCachePolicy
+	// MaxEntryBytes bounds the complete serialized envelope. A value less than
+	// or equal to zero uses DefaultMaxResponseBytes.
+	MaxEntryBytes int64
+}
+
+type cacheCall struct {
+	done    chan struct{}
+	result  CacheLookupResult
+	err     error
+	waiters int
+}
+
+// CacheCoordinator applies cache policies and coalesces concurrent provider
+// fetches for the same canonical key within one process.
+type CacheCoordinator struct {
+	cache          Cache
+	clock          CacheClock
+	sourcePolicies map[string]SourceCachePolicy
+	maxEntryBytes  int64
+
+	mu       sync.Mutex
+	inflight map[string]*cacheCall
+}
+
+// NewCacheCoordinator validates configuration and returns a reusable
+// coordinator. SourcePolicies must explicitly name every source; there is no
+// global TTL fallback.
+func NewCacheCoordinator(config CacheCoordinatorConfig) (*CacheCoordinator, error) {
+	if config.Cache == nil {
+		return nil, invalidInputError("cache backend is required")
+	}
+	if len(config.SourcePolicies) == 0 {
+		return nil, invalidInputError("at least one source-specific cache policy is required")
+	}
+
+	policies := make(map[string]SourceCachePolicy, len(config.SourcePolicies))
+	for source, policy := range config.SourcePolicies {
+		normalizedSource := strings.ToLower(strings.TrimSpace(source))
+		if normalizedSource == "" {
+			return nil, invalidInputError("cache policy source is required")
+		}
+		if err := policy.validate(normalizedSource); err != nil {
+			return nil, err
+		}
+		if _, duplicate := policies[normalizedSource]; duplicate {
+			return nil, invalidInputError(fmt.Sprintf("duplicate cache policy source %q", normalizedSource))
+		}
+		policies[normalizedSource] = policy
+	}
+
+	clock := config.Clock
+	if clock == nil {
+		clock = systemCacheClock{}
+	}
+	maxEntryBytes := config.MaxEntryBytes
+	if maxEntryBytes <= 0 {
+		maxEntryBytes = DefaultMaxResponseBytes
+	}
+
+	return &CacheCoordinator{
+		cache:          config.Cache,
+		clock:          clock,
+		sourcePolicies: policies,
+		maxEntryBytes:  maxEntryBytes,
+		inflight:       make(map[string]*cacheCall),
+	}, nil
+}
+
+// Lookup applies the requested cache policy around fetch. fetch should perform
+// exactly one provider operation and return its stable classified error. It is
+// never called for a fresh hit or a FreshOnly miss.
+func (coordinator *CacheCoordinator) Lookup(ctx context.Context, request CacheRequest, fetch CacheFetchFunc) (CacheLookupResult, error) {
+	if ctx == nil {
+		return CacheLookupResult{}, invalidInputError("cache lookup context is required")
+	}
+	if fetch == nil {
+		return CacheLookupResult{}, invalidInputError("cache fetch function is required")
+	}
+	if !request.Policy.valid() {
+		return CacheLookupResult{}, invalidInputError(fmt.Sprintf("unknown cache policy %q", request.Policy))
+	}
+	if err := ctx.Err(); err != nil {
+		return CacheLookupResult{}, classifiedContextError(err)
+	}
+
+	spec, err := normalizeCacheKeySpec(request.Key)
+	if err != nil {
+		return CacheLookupResult{}, err
+	}
+	key, err := CanonicalCacheKey(spec)
+	if err != nil {
+		return CacheLookupResult{}, err
+	}
+	sourcePolicy, ok := coordinator.sourcePolicies[spec.Source]
+	if !ok {
+		return CacheLookupResult{}, invalidInputError(fmt.Sprintf("no cache policy configured for source %q", spec.Source))
+	}
+
+	if request.Policy == CachePolicyBypass {
+		return coordinator.fetch(ctx, key, spec, sourcePolicy, request.Policy, fetch, CacheEnvelope{}, nil)
+	}
+
+	var (
+		cached     CacheEnvelope
+		cacheFound bool
+		cacheErr   error
+	)
+	if request.Policy != CachePolicyRefresh {
+		cached, cacheFound, cacheErr = coordinator.get(ctx, key, spec)
+		if cacheErr != nil && request.Policy == CachePolicyFreshOnly {
+			return CacheLookupResult{CacheError: cacheErr}, cacheErr
+		}
+		if cacheFound && coordinator.clock.Now().UTC().Before(cached.ExpiresAt) {
+			result := CacheLookupResult{Envelope: cached, State: CacheStateHit, CacheHit: true}
+			if cached.ProviderErrorClass != ProviderErrorNone {
+				return result, &CachedProviderError{Class: cached.ProviderErrorClass, Source: cached.Source, FetchedAt: cached.FetchedAt}
+			}
+			return result, nil
+		}
+	}
+
+	if request.Policy == CachePolicyFreshOnly {
+		if cacheFound {
+			staleErr := &CacheError{Operation: "get", Key: key, Err: ErrCacheStale}
+			return CacheLookupResult{Envelope: cached, State: CacheStateStale, CacheHit: true, Stale: true, CacheError: staleErr}, staleErr
+		}
+		missErr := &CacheError{Operation: "get", Key: key, Err: ErrCacheMiss}
+		return CacheLookupResult{CacheError: missErr}, missErr
+	}
+
+	// Policies are part of in-process coordination even though they are not
+	// part of the stored key. This prevents a stale-if-error caller from
+	// changing the fallback semantics observed by a concurrent read-through.
+	inflightKey := key + "\x00" + string(request.Policy)
+	return coordinator.coalescedFetch(ctx, inflightKey, func() (CacheLookupResult, error) {
+		return coordinator.fetch(ctx, key, spec, sourcePolicy, request.Policy, fetch, cached, cacheErr)
+	})
+}
+
+func (coordinator *CacheCoordinator) get(ctx context.Context, key string, spec CacheKeySpec) (CacheEnvelope, bool, error) {
+	entry, found, err := coordinator.cache.Get(ctx, key)
+	if err != nil {
+		return CacheEnvelope{}, false, &CacheError{Operation: "get", Key: key, Err: fmt.Errorf("%w: %w", ErrCacheUnavailable, err)}
+	}
+	if !found {
+		return CacheEnvelope{}, false, nil
+	}
+	if err := coordinator.validateEnvelope(key, spec, entry); err != nil {
+		return CacheEnvelope{}, false, &CacheError{Operation: "get", Key: key, Err: err}
+	}
+	return entry, true, nil
+}
+
+func (coordinator *CacheCoordinator) validateEnvelope(key string, spec CacheKeySpec, entry CacheEnvelope) error {
+	if entry.Version != CacheEnvelopeVersion || entry.Key != key || entry.Source != spec.Source ||
+		entry.Endpoint != spec.Endpoint || entry.Protocol != spec.Protocol ||
+		entry.NormalizedQuery != spec.NormalizedQuery || entry.ParserVersion != spec.ParserVersion ||
+		entry.ResultSchemaVersion != spec.ResultSchemaVersion || entry.FetchedAt.IsZero() || entry.ExpiresAt.IsZero() ||
+		!entry.ExpiresAt.After(entry.FetchedAt) {
+		return ErrInvalidCacheEntry
+	}
+	if entry.ProviderErrorClass == ProviderErrorNone {
+		if len(entry.NormalizedResult) == 0 || !json.Valid(entry.NormalizedResult) {
+			return ErrInvalidCacheEntry
+		}
+	} else {
+		if providerErrorSentinel(entry.ProviderErrorClass) == nil || len(entry.NormalizedResult) != 0 {
+			return ErrInvalidCacheEntry
+		}
+	}
+	if strings.TrimSpace(entry.Provenance.Provider) == "" || strings.TrimSpace(entry.Provenance.Endpoint) == "" || strings.TrimSpace(entry.Provenance.Protocol) == "" {
+		return ErrInvalidCacheEntry
+	}
+	return coordinator.validateEntrySize(entry)
+}
+
+func (coordinator *CacheCoordinator) validateEntrySize(entry CacheEnvelope) error {
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("%w: encode envelope: %v", ErrInvalidCacheEntry, err)
+	}
+	if int64(len(encoded)) > coordinator.maxEntryBytes {
+		return &CacheEntryTooLargeError{Limit: coordinator.maxEntryBytes}
+	}
+	return nil
+}
+
+func (coordinator *CacheCoordinator) fetch(
+	ctx context.Context,
+	key string,
+	spec CacheKeySpec,
+	sourcePolicy SourceCachePolicy,
+	requestPolicy CachePolicy,
+	fetch func(context.Context) (CacheFetchResult, error),
+	stale CacheEnvelope,
+	priorCacheErr error,
+) (CacheLookupResult, error) {
+	if err := ctx.Err(); err != nil {
+		return CacheLookupResult{CacheError: priorCacheErr}, classifiedContextError(err)
+	}
+
+	fetched, providerErr := fetch(ctx)
+	fetchedAt := coordinator.clock.Now().UTC()
+	providerClass := ClassifyProviderError(providerErr)
+
+	if providerErr != nil && requestPolicy == CachePolicyStaleIfError &&
+		stale.ProviderErrorClass == ProviderErrorNone && coordinator.canUseStale(stale, fetchedAt, sourcePolicy.MaxStale) &&
+		ctx.Err() == nil && providerClass != ProviderErrorCanceled {
+		return CacheLookupResult{
+			Envelope:          stale,
+			State:             CacheStateStale,
+			CacheHit:          true,
+			Stale:             true,
+			CacheError:        priorCacheErr,
+			RefreshErrorClass: providerClass,
+		}, nil
+	}
+
+	ttl := sourcePolicy.SuccessTTL
+	if providerErr != nil {
+		switch providerClass {
+		case ProviderErrorNoRecords:
+			ttl = sourcePolicy.NoRecordsTTL
+		case ProviderErrorRateLimited:
+			ttl = sourcePolicy.RateLimitedTTL
+		default:
+			ttl = 0
+		}
+	}
+
+	entry := CacheEnvelope{
+		Version:             CacheEnvelopeVersion,
+		Key:                 key,
+		Source:              spec.Source,
+		Endpoint:            spec.Endpoint,
+		Protocol:            spec.Protocol,
+		NormalizedQuery:     spec.NormalizedQuery,
+		ParserVersion:       spec.ParserVersion,
+		FetchedAt:           fetchedAt,
+		ResultSchemaVersion: spec.ResultSchemaVersion,
+		ProviderErrorClass:  providerClass,
+		Provenance:          normalizeProvenance(fetched.Provenance, spec),
+	}
+	if ttl > 0 {
+		entry.ExpiresAt = fetchedAt.Add(ttl)
+	}
+	if providerErr == nil {
+		entry.NormalizedResult = append(json.RawMessage(nil), fetched.NormalizedResult...)
+		if len(entry.NormalizedResult) == 0 || !json.Valid(entry.NormalizedResult) {
+			return CacheLookupResult{CacheError: priorCacheErr}, fmt.Errorf("%w: normalized result must be valid JSON", ErrInvalidCacheEntry)
+		}
+	}
+
+	state := CacheStateRefreshed
+	if requestPolicy == CachePolicyBypass || ttl == 0 {
+		state = CacheStateBypassed
+		if requestPolicy != CachePolicyBypass {
+			state = CacheStateProvider
+		}
+	}
+	result := CacheLookupResult{
+		Envelope:   entry,
+		State:      state,
+		CacheError: priorCacheErr,
+	}
+
+	if requestPolicy != CachePolicyBypass && ttl > 0 {
+		if err := coordinator.validateEnvelope(key, spec, entry); err != nil {
+			result.State = CacheStateProvider
+			result.CacheError = &CacheError{Operation: "set", Key: key, Err: err}
+			if providerErr != nil {
+				return result, providerErr
+			}
+			return result, nil
+		}
+		if err := coordinator.cache.Set(ctx, key, entry); err != nil {
+			result.State = CacheStateProvider
+			result.CacheError = &CacheError{Operation: "set", Key: key, Err: fmt.Errorf("%w: %w", ErrCacheUnavailable, err)}
+		}
+	}
+
+	if providerErr != nil {
+		return result, providerErr
+	}
+	return result, nil
+}
+
+func normalizeProvenance(provenance CacheProvenance, spec CacheKeySpec) CacheProvenance {
+	if strings.TrimSpace(provenance.Provider) == "" {
+		provenance.Provider = spec.Source
+	}
+	if strings.TrimSpace(provenance.Endpoint) == "" {
+		provenance.Endpoint = spec.Endpoint
+	}
+	if strings.TrimSpace(provenance.Protocol) == "" {
+		provenance.Protocol = spec.Protocol
+	}
+	return provenance
+}
+
+func (coordinator *CacheCoordinator) canUseStale(entry CacheEnvelope, now time.Time, maxStale time.Duration) bool {
+	return !entry.ExpiresAt.IsZero() && maxStale > 0 && !now.Before(entry.ExpiresAt) && now.Sub(entry.ExpiresAt) <= maxStale
+}
+
+func (coordinator *CacheCoordinator) coalescedFetch(ctx context.Context, key string, fetch func() (CacheLookupResult, error)) (CacheLookupResult, error) {
+	coordinator.mu.Lock()
+	if call, ok := coordinator.inflight[key]; ok {
+		call.waiters++
+		coordinator.mu.Unlock()
+		select {
+		case <-call.done:
+			result := call.result
+			result.Coalesced = true
+			return result, call.err
+		case <-ctx.Done():
+			return CacheLookupResult{Coalesced: true}, classifiedContextError(ctx.Err())
+		}
+	}
+
+	call := &cacheCall{done: make(chan struct{})}
+	coordinator.inflight[key] = call
+	coordinator.mu.Unlock()
+
+	call.result, call.err = fetch()
+	close(call.done)
+
+	coordinator.mu.Lock()
+	delete(coordinator.inflight, key)
+	coordinator.mu.Unlock()
+	return call.result, call.err
+}
+
+func classifiedContextError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", ErrTimeout, err)
+	}
+	return fmt.Errorf("%w: %w", ErrCanceled, err)
+}
+
+// MemoryCache is a bounded-by-coordinator, process-local implementation of
+// Cache. Entries are copied on read and write so callers cannot mutate stored
+// byte slices or provenance maps.
+type MemoryCache struct {
+	mu      sync.RWMutex
+	entries map[string]CacheEnvelope
+}
+
+// NewMemoryCache returns an empty concurrency-safe in-memory cache.
+func NewMemoryCache() *MemoryCache {
+	return &MemoryCache{entries: make(map[string]CacheEnvelope)}
+}
+
+func (cache *MemoryCache) Get(ctx context.Context, key string) (CacheEnvelope, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return CacheEnvelope{}, false, err
+	}
+	cache.mu.RLock()
+	entry, found := cache.entries[key]
+	cache.mu.RUnlock()
+	if !found {
+		return CacheEnvelope{}, false, nil
+	}
+	return cloneCacheEnvelope(entry), true, nil
+}
+
+func (cache *MemoryCache) Set(ctx context.Context, key string, entry CacheEnvelope) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cache.mu.Lock()
+	if cache.entries == nil {
+		cache.entries = make(map[string]CacheEnvelope)
+	}
+	cache.entries[key] = cloneCacheEnvelope(entry)
+	cache.mu.Unlock()
+	return nil
+}
+
+func (cache *MemoryCache) Delete(ctx context.Context, key string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cache.mu.Lock()
+	delete(cache.entries, key)
+	cache.mu.Unlock()
+	return nil
+}
+
+func cloneCacheEnvelope(entry CacheEnvelope) CacheEnvelope {
+	entry.NormalizedResult = append(json.RawMessage(nil), entry.NormalizedResult...)
+	if entry.Provenance.Details != nil {
+		details := make(map[string]string, len(entry.Provenance.Details))
+		for key, value := range entry.Provenance.Details {
+			details[key] = value
+		}
+		entry.Provenance.Details = details
+	}
+	return entry
+}

--- a/cache.go
+++ b/cache.go
@@ -685,9 +685,7 @@ func (coordinator *CacheCoordinator) coalescedFetch(ctx context.Context, key str
 		coordinator.mu.Unlock()
 		select {
 		case <-call.done:
-			result := call.result
-			result.Coalesced = true
-			return result, call.err
+			return completedCacheCall(ctx, call)
 		case <-ctx.Done():
 			return CacheLookupResult{Coalesced: true}, classifiedContextError(ctx.Err())
 		}
@@ -704,6 +702,18 @@ func (coordinator *CacheCoordinator) coalescedFetch(ctx context.Context, key str
 	delete(coordinator.inflight, key)
 	coordinator.mu.Unlock()
 	return call.result, call.err
+}
+
+func completedCacheCall(ctx context.Context, call *cacheCall) (CacheLookupResult, error) {
+	// The call and context can become ready together. Recheck cancellation
+	// after receiving the shared result so select cannot return provider or
+	// stale data past this waiter's deadline.
+	if err := ctx.Err(); err != nil {
+		return CacheLookupResult{Coalesced: true}, classifiedContextError(err)
+	}
+	result := call.result
+	result.Coalesced = true
+	return result, call.err
 }
 
 func classifiedContextError(err error) error {

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,619 @@
+package pwhois
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var cacheTestTime = time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+
+type fakeCacheClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (clock *fakeCacheClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *fakeCacheClock) Advance(duration time.Duration) {
+	clock.mu.Lock()
+	clock.now = clock.now.Add(duration)
+	clock.mu.Unlock()
+}
+
+type fakeCache struct {
+	mu          sync.Mutex
+	entries     map[string]CacheEnvelope
+	getError    error
+	setError    error
+	getCalls    int
+	setCalls    int
+	deleteCalls int
+}
+
+func newFakeCache() *fakeCache {
+	return &fakeCache{entries: make(map[string]CacheEnvelope)}
+}
+
+func (cache *fakeCache) Get(ctx context.Context, key string) (CacheEnvelope, bool, error) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.getCalls++
+	if cache.getError != nil {
+		return CacheEnvelope{}, false, cache.getError
+	}
+	entry, found := cache.entries[key]
+	return cloneCacheEnvelope(entry), found, nil
+}
+
+func (cache *fakeCache) Set(ctx context.Context, key string, entry CacheEnvelope) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.setCalls++
+	if cache.setError != nil {
+		return cache.setError
+	}
+	cache.entries[key] = cloneCacheEnvelope(entry)
+	return nil
+}
+
+func (cache *fakeCache) Delete(ctx context.Context, key string) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.deleteCalls++
+	delete(cache.entries, key)
+	return nil
+}
+
+func (cache *fakeCache) counts() (int, int) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	return cache.getCalls, cache.setCalls
+}
+
+func testCacheKey(source string) CacheKeySpec {
+	return CacheKeySpec{
+		Source:              source,
+		Endpoint:            "whois.example.test:43",
+		Protocol:            "pwhois",
+		NormalizedQuery:     "192.0.2.1",
+		Options:             map[string]string{"lookup": "ip"},
+		ParserVersion:       "ip-v1",
+		ResultSchemaVersion: "whois-v1",
+	}
+}
+
+func testCacheCoordinator(t *testing.T, cache Cache, clock CacheClock) *CacheCoordinator {
+	t.Helper()
+	coordinator, err := NewCacheCoordinator(CacheCoordinatorConfig{
+		Cache: cache,
+		Clock: clock,
+		SourcePolicies: map[string]SourceCachePolicy{
+			"pwhois": {
+				SuccessTTL:     time.Hour,
+				NoRecordsTTL:   5 * time.Minute,
+				RateLimitedTTL: time.Minute,
+				MaxStale:       30 * time.Minute,
+			},
+			"alternative": {
+				SuccessTTL:     2 * time.Hour,
+				NoRecordsTTL:   10 * time.Minute,
+				RateLimitedTTL: 2 * time.Minute,
+				MaxStale:       time.Hour,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewCacheCoordinator() error = %v", err)
+	}
+	return coordinator
+}
+
+func successfulCacheFetch(result string) func(context.Context) (CacheFetchResult, error) {
+	return func(context.Context) (CacheFetchResult, error) {
+		return CacheFetchResult{
+			NormalizedResult: json.RawMessage(result),
+			Provenance: CacheProvenance{
+				Provider: "pwhois",
+				Details:  map[string]string{"parser": "ip"},
+			},
+		}, nil
+	}
+}
+
+func TestCanonicalCacheKeyIsSourceAwareAndDeterministic(t *testing.T) {
+	first := testCacheKey("PWHOIS")
+	first.Options = map[string]string{"z": "last", "a": "first"}
+	second := testCacheKey("pwhois")
+	second.Options = map[string]string{"a": "first", "z": "last"}
+
+	firstKey, err := CanonicalCacheKey(first)
+	if err != nil {
+		t.Fatalf("CanonicalCacheKey(first) error = %v", err)
+	}
+	secondKey, err := CanonicalCacheKey(second)
+	if err != nil {
+		t.Fatalf("CanonicalCacheKey(second) error = %v", err)
+	}
+	if firstKey != secondKey {
+		t.Fatalf("keys with reordered options differ:\n%s\n%s", firstKey, secondKey)
+	}
+
+	alternative := second
+	alternative.Source = "alternative"
+	alternativeKey, err := CanonicalCacheKey(alternative)
+	if err != nil {
+		t.Fatalf("CanonicalCacheKey(alternative) error = %v", err)
+	}
+	if alternativeKey == secondKey {
+		t.Fatal("identical query collided across sources")
+	}
+
+	changedEndpoint := second
+	changedEndpoint.Endpoint = "other.example.test:43"
+	changedEndpointKey, err := CanonicalCacheKey(changedEndpoint)
+	if err != nil {
+		t.Fatalf("CanonicalCacheKey(changed endpoint) error = %v", err)
+	}
+	if changedEndpointKey == secondKey {
+		t.Fatal("identical query collided across endpoints")
+	}
+}
+
+func TestCanonicalCacheKeyRequiresContractVersions(t *testing.T) {
+	key := testCacheKey("pwhois")
+	key.ParserVersion = ""
+	if _, err := CanonicalCacheKey(key); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("CanonicalCacheKey() error = %v, want ErrInvalidInput", err)
+	}
+
+	key = testCacheKey("pwhois")
+	key.ResultSchemaVersion = ""
+	if _, err := CanonicalCacheKey(key); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("CanonicalCacheKey() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestCacheCoordinatorReadThroughThenHit(t *testing.T) {
+	clock := &fakeCacheClock{now: cacheTestTime}
+	cache := newFakeCache()
+	coordinator := testCacheCoordinator(t, cache, clock)
+	request := CacheRequest{Key: testCacheKey("pwhois"), Policy: CachePolicyReadThrough}
+	var fetchCalls int
+	fetch := func(ctx context.Context) (CacheFetchResult, error) {
+		fetchCalls++
+		return successfulCacheFetch(`{"ip":"192.0.2.1"}`)(ctx)
+	}
+
+	first, err := coordinator.Lookup(context.Background(), request, fetch)
+	if err != nil {
+		t.Fatalf("first Lookup() error = %v", err)
+	}
+	if first.State != CacheStateRefreshed || first.CacheHit || first.Stale {
+		t.Fatalf("first Lookup() state = %+v", first)
+	}
+	if first.Envelope.Source != "pwhois" || first.Envelope.NormalizedQuery != "192.0.2.1" {
+		t.Fatalf("first envelope provenance = %+v", first.Envelope)
+	}
+	if !first.Envelope.FetchedAt.Equal(cacheTestTime) || !first.Envelope.ExpiresAt.Equal(cacheTestTime.Add(time.Hour)) {
+		t.Fatalf("first envelope times = %v to %v", first.Envelope.FetchedAt, first.Envelope.ExpiresAt)
+	}
+
+	second, err := coordinator.Lookup(context.Background(), request, fetch)
+	if err != nil {
+		t.Fatalf("second Lookup() error = %v", err)
+	}
+	if second.State != CacheStateHit || !second.CacheHit || second.Stale {
+		t.Fatalf("second Lookup() state = %+v", second)
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("fetch calls = %d, want 1", fetchCalls)
+	}
+	getCalls, setCalls := cache.counts()
+	if getCalls != 2 || setCalls != 1 {
+		t.Fatalf("cache calls = get %d, set %d; want get 2, set 1", getCalls, setCalls)
+	}
+}
+
+func TestCacheCoordinatorPolicyBehavior(t *testing.T) {
+	tests := []struct {
+		name         string
+		policy       CachePolicy
+		seedFresh    bool
+		seedStale    bool
+		wantFetches  int
+		wantState    CacheState
+		wantCacheHit bool
+		wantError    error
+	}{
+		{name: "bypass ignores fresh entry", policy: CachePolicyBypass, seedFresh: true, wantFetches: 1, wantState: CacheStateBypassed},
+		{name: "refresh ignores fresh entry", policy: CachePolicyRefresh, seedFresh: true, wantFetches: 1, wantState: CacheStateRefreshed},
+		{name: "fresh only hit", policy: CachePolicyFreshOnly, seedFresh: true, wantFetches: 0, wantState: CacheStateHit, wantCacheHit: true},
+		{name: "fresh only miss", policy: CachePolicyFreshOnly, wantFetches: 0, wantError: ErrCacheMiss},
+		{name: "fresh only stale", policy: CachePolicyFreshOnly, seedStale: true, wantFetches: 0, wantState: CacheStateStale, wantCacheHit: true, wantError: ErrCacheStale},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := &fakeCacheClock{now: cacheTestTime}
+			cache := newFakeCache()
+			coordinator := testCacheCoordinator(t, cache, clock)
+			keySpec := testCacheKey("pwhois")
+			key, err := CanonicalCacheKey(keySpec)
+			if err != nil {
+				t.Fatalf("CanonicalCacheKey() error = %v", err)
+			}
+			if test.seedFresh || test.seedStale {
+				expiresAt := cacheTestTime.Add(time.Hour)
+				if test.seedStale {
+					expiresAt = cacheTestTime.Add(-time.Minute)
+				}
+				cache.entries[key] = CacheEnvelope{
+					Version: CacheEnvelopeVersion, Key: key, Source: "pwhois",
+					Endpoint: keySpec.Endpoint, Protocol: keySpec.Protocol, NormalizedQuery: keySpec.NormalizedQuery,
+					ParserVersion: keySpec.ParserVersion, FetchedAt: expiresAt.Add(-time.Hour), ExpiresAt: expiresAt,
+					ResultSchemaVersion: keySpec.ResultSchemaVersion, NormalizedResult: json.RawMessage(`{"seeded":true}`),
+					Provenance: CacheProvenance{Provider: "pwhois", Endpoint: keySpec.Endpoint, Protocol: keySpec.Protocol},
+				}
+			}
+
+			fetchCalls := 0
+			result, lookupErr := coordinator.Lookup(context.Background(), CacheRequest{Key: keySpec, Policy: test.policy}, func(ctx context.Context) (CacheFetchResult, error) {
+				fetchCalls++
+				return successfulCacheFetch(`{"fresh":true}`)(ctx)
+			})
+			if !errors.Is(lookupErr, test.wantError) {
+				t.Fatalf("Lookup() error = %v, want %v", lookupErr, test.wantError)
+			}
+			if fetchCalls != test.wantFetches {
+				t.Fatalf("fetch calls = %d, want %d", fetchCalls, test.wantFetches)
+			}
+			if result.State != test.wantState || result.CacheHit != test.wantCacheHit {
+				t.Fatalf("Lookup() state = %+v, want state %q hit %t", result, test.wantState, test.wantCacheHit)
+			}
+		})
+	}
+}
+
+func TestCacheCoordinatorUsesSourceSpecificTTLs(t *testing.T) {
+	clock := &fakeCacheClock{now: cacheTestTime}
+	cache := newFakeCache()
+	coordinator := testCacheCoordinator(t, cache, clock)
+
+	result, err := coordinator.Lookup(context.Background(), CacheRequest{Key: testCacheKey("alternative"), Policy: CachePolicyReadThrough}, successfulCacheFetch(`{"ok":true}`))
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if got := result.Envelope.ExpiresAt.Sub(result.Envelope.FetchedAt); got != 2*time.Hour {
+		t.Fatalf("alternative success TTL = %v, want 2h", got)
+	}
+}
+
+func TestCacheCoordinatorNegativeAndRateLimitCaching(t *testing.T) {
+	tests := []struct {
+		name      string
+		fetchErr  error
+		wantError error
+		wantClass ProviderErrorClass
+		wantTTL   time.Duration
+	}{
+		{name: "no records", fetchErr: fmt.Errorf("query: %w", ErrNoRecords), wantError: ErrNoRecords, wantClass: ProviderErrorNoRecords, wantTTL: 5 * time.Minute},
+		{name: "rate limited", fetchErr: fmt.Errorf("query: %w", ErrRateLimited), wantError: ErrRateLimited, wantClass: ProviderErrorRateLimited, wantTTL: time.Minute},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := &fakeCacheClock{now: cacheTestTime}
+			cache := newFakeCache()
+			coordinator := testCacheCoordinator(t, cache, clock)
+			request := CacheRequest{Key: testCacheKey("pwhois"), Policy: CachePolicyReadThrough}
+			fetchCalls := 0
+			fetch := func(context.Context) (CacheFetchResult, error) {
+				fetchCalls++
+				return CacheFetchResult{}, test.fetchErr
+			}
+
+			first, err := coordinator.Lookup(context.Background(), request, fetch)
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("first Lookup() error = %v, want %v", err, test.wantError)
+			}
+			if first.Envelope.ProviderErrorClass != test.wantClass {
+				t.Fatalf("provider class = %q, want %q", first.Envelope.ProviderErrorClass, test.wantClass)
+			}
+			if got := first.Envelope.ExpiresAt.Sub(first.Envelope.FetchedAt); got != test.wantTTL {
+				t.Fatalf("negative TTL = %v, want %v", got, test.wantTTL)
+			}
+
+			second, err := coordinator.Lookup(context.Background(), request, fetch)
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("second Lookup() error = %v, want stable class from cached result", err)
+			}
+			var cachedErr *CachedProviderError
+			if !errors.As(err, &cachedErr) {
+				t.Fatalf("second Lookup() error type = %T, want *CachedProviderError", err)
+			}
+			if second.State != CacheStateHit || !second.CacheHit || fetchCalls != 1 {
+				t.Fatalf("second Lookup() = %+v, fetch calls %d", second, fetchCalls)
+			}
+		})
+	}
+}
+
+func TestCacheCoordinatorStaleIfErrorIsBounded(t *testing.T) {
+	clock := &fakeCacheClock{now: cacheTestTime}
+	cache := newFakeCache()
+	coordinator := testCacheCoordinator(t, cache, clock)
+	request := CacheRequest{Key: testCacheKey("pwhois"), Policy: CachePolicyReadThrough}
+
+	if _, err := coordinator.Lookup(context.Background(), request, successfulCacheFetch(`{"generation":1}`)); err != nil {
+		t.Fatalf("seed Lookup() error = %v", err)
+	}
+	clock.Advance(time.Hour + 10*time.Minute)
+	request.Policy = CachePolicyStaleIfError
+
+	stale, err := coordinator.Lookup(context.Background(), request, func(context.Context) (CacheFetchResult, error) {
+		return CacheFetchResult{}, fmt.Errorf("temporary failure: %w", ErrConnection)
+	})
+	if err != nil {
+		t.Fatalf("stale Lookup() error = %v", err)
+	}
+	if stale.State != CacheStateStale || !stale.CacheHit || !stale.Stale || stale.RefreshErrorClass != ProviderErrorConnection {
+		t.Fatalf("stale Lookup() result = %+v", stale)
+	}
+
+	clock.Advance(21 * time.Minute)
+	outside, err := coordinator.Lookup(context.Background(), request, func(context.Context) (CacheFetchResult, error) {
+		return CacheFetchResult{}, fmt.Errorf("temporary failure: %w", ErrConnection)
+	})
+	if !errors.Is(err, ErrConnection) {
+		t.Fatalf("outside-window Lookup() error = %v, want ErrConnection", err)
+	}
+	if outside.Stale {
+		t.Fatalf("outside-window Lookup() returned stale data: %+v", outside)
+	}
+}
+
+func TestCacheCoordinatorDoesNotHideCancellationWithStaleData(t *testing.T) {
+	clock := &fakeCacheClock{now: cacheTestTime}
+	cache := newFakeCache()
+	coordinator := testCacheCoordinator(t, cache, clock)
+	request := CacheRequest{Key: testCacheKey("pwhois"), Policy: CachePolicyReadThrough}
+	if _, err := coordinator.Lookup(context.Background(), request, successfulCacheFetch(`{"ok":true}`)); err != nil {
+		t.Fatalf("seed Lookup() error = %v", err)
+	}
+	clock.Advance(time.Hour + time.Minute)
+	request.Policy = CachePolicyStaleIfError
+
+	result, err := coordinator.Lookup(context.Background(), request, func(context.Context) (CacheFetchResult, error) {
+		return CacheFetchResult{}, fmt.Errorf("caller stopped: %w", ErrCanceled)
+	})
+	if !errors.Is(err, ErrCanceled) {
+		t.Fatalf("Lookup() error = %v, want ErrCanceled", err)
+	}
+	if result.Stale {
+		t.Fatalf("Lookup() hid cancellation with stale data: %+v", result)
+	}
+}
+
+func TestCacheCoordinatorUsesStaleDataForProviderTimeout(t *testing.T) {
+	clock := &fakeCacheClock{now: cacheTestTime}
+	cache := newFakeCache()
+	coordinator := testCacheCoordinator(t, cache, clock)
+	request := CacheRequest{Key: testCacheKey("pwhois"), Policy: CachePolicyReadThrough}
+	if _, err := coordinator.Lookup(context.Background(), request, successfulCacheFetch(`{"ok":true}`)); err != nil {
+		t.Fatalf("seed Lookup() error = %v", err)
+	}
+	clock.Advance(time.Hour + time.Minute)
+	request.Policy = CachePolicyStaleIfError
+
+	result, err := coordinator.Lookup(context.Background(), request, func(context.Context) (CacheFetchResult, error) {
+		return CacheFetchResult{}, fmt.Errorf("provider timed out: %w", ErrTimeout)
+	})
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if !result.Stale || result.RefreshErrorClass != ProviderErrorTimeout {
+		t.Fatalf("Lookup() result = %+v, want stale timeout fallback", result)
+	}
+}
+
+func TestCacheCoordinatorSurfacesBackendFailureSeparately(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*fakeCache, error)
+		wantState CacheState
+	}{
+		{name: "read failure", configure: func(cache *fakeCache, backendErr error) { cache.getError = backendErr }, wantState: CacheStateRefreshed},
+		{name: "write failure", configure: func(cache *fakeCache, backendErr error) { cache.setError = backendErr }, wantState: CacheStateProvider},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := &fakeCacheClock{now: cacheTestTime}
+			cache := newFakeCache()
+			backendErr := errors.New("backend unavailable")
+			test.configure(cache, backendErr)
+			coordinator := testCacheCoordinator(t, cache, clock)
+
+			result, err := coordinator.Lookup(context.Background(), CacheRequest{Key: testCacheKey("pwhois"), Policy: CachePolicyReadThrough}, successfulCacheFetch(`{"ok":true}`))
+			if err != nil {
+				t.Fatalf("Lookup() provider error = %v", err)
+			}
+			if result.State != test.wantState || result.CacheError == nil || !errors.Is(result.CacheError, ErrCacheUnavailable) || !errors.Is(result.CacheError, backendErr) {
+				t.Fatalf("Lookup() result = %+v, want usable provider result with cache error", result)
+			}
+			if result.Envelope.ProviderErrorClass != ProviderErrorNone {
+				t.Fatalf("cache failure was represented as provider class %q", result.Envelope.ProviderErrorClass)
+			}
+		})
+	}
+}
+
+func TestCacheCoordinatorRejectsOversizedEnvelope(t *testing.T) {
+	clock := &fakeCacheClock{now: cacheTestTime}
+	cache := newFakeCache()
+	coordinator, err := NewCacheCoordinator(CacheCoordinatorConfig{
+		Cache:         cache,
+		Clock:         clock,
+		MaxEntryBytes: 256,
+		SourcePolicies: map[string]SourceCachePolicy{
+			"pwhois": {SuccessTTL: time.Hour},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewCacheCoordinator() error = %v", err)
+	}
+
+	result, err := coordinator.Lookup(context.Background(), CacheRequest{Key: testCacheKey("pwhois"), Policy: CachePolicyReadThrough}, successfulCacheFetch(`{"data":"`+strings.Repeat("x", 512)+`"}`))
+	if err != nil {
+		t.Fatalf("Lookup() provider error = %v", err)
+	}
+	if result.State != CacheStateProvider || !errors.Is(result.CacheError, ErrCacheEntryTooLarge) {
+		t.Fatalf("Lookup() result = %+v, want usable provider result with ErrCacheEntryTooLarge", result)
+	}
+	if len(result.Envelope.NormalizedResult) == 0 {
+		t.Fatal("oversized cache entry discarded usable provider result")
+	}
+	_, setCalls := cache.counts()
+	if setCalls != 0 {
+		t.Fatalf("cache Set calls = %d, want 0", setCalls)
+	}
+}
+
+func TestCacheEnvelopeContainsNoRawResponseField(t *testing.T) {
+	entry := CacheEnvelope{
+		Version:          CacheEnvelopeVersion,
+		NormalizedResult: json.RawMessage(`{"safe":"normalized"}`),
+	}
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(encoded), "raw_response") || strings.Contains(string(encoded), "provider_payload") {
+		t.Fatalf("cache envelope exposed raw-response field: %s", encoded)
+	}
+}
+
+func TestCacheCoordinatorCoalescesConcurrentMisses(t *testing.T) {
+	const workers = 16
+	clock := &fakeCacheClock{now: cacheTestTime}
+	cache := newFakeCache()
+	coordinator := testCacheCoordinator(t, cache, clock)
+	request := CacheRequest{Key: testCacheKey("pwhois"), Policy: CachePolicyReadThrough}
+	key, err := CanonicalCacheKey(request.Key)
+	if err != nil {
+		t.Fatalf("CanonicalCacheKey() error = %v", err)
+	}
+
+	start := make(chan struct{})
+	releaseFetch := make(chan struct{})
+	var fetchCalls atomic.Int32
+	fetch := func(context.Context) (CacheFetchResult, error) {
+		fetchCalls.Add(1)
+		<-releaseFetch
+		return CacheFetchResult{NormalizedResult: json.RawMessage(`{"ok":true}`)}, nil
+	}
+
+	type outcome struct {
+		result CacheLookupResult
+		err    error
+	}
+	outcomes := make(chan outcome, workers)
+	for worker := 0; worker < workers; worker++ {
+		go func() {
+			<-start
+			result, lookupErr := coordinator.Lookup(context.Background(), request, fetch)
+			outcomes <- outcome{result: result, err: lookupErr}
+		}()
+	}
+	close(start)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		coordinator.mu.Lock()
+		call := coordinator.inflight[key+"\x00"+string(request.Policy)]
+		waiters := 0
+		if call != nil {
+			waiters = call.waiters
+		}
+		coordinator.mu.Unlock()
+		if waiters == workers-1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			close(releaseFetch)
+			t.Fatalf("coalesced waiters = %d, want %d", waiters, workers-1)
+		}
+		runtime.Gosched()
+	}
+	close(releaseFetch)
+
+	coalesced := 0
+	for worker := 0; worker < workers; worker++ {
+		outcome := <-outcomes
+		if outcome.err != nil {
+			t.Errorf("Lookup() error = %v", outcome.err)
+		}
+		if outcome.result.Coalesced {
+			coalesced++
+		}
+	}
+	if fetchCalls.Load() != 1 {
+		t.Fatalf("fetch calls = %d, want 1", fetchCalls.Load())
+	}
+	if coalesced != workers-1 {
+		t.Fatalf("coalesced results = %d, want %d", coalesced, workers-1)
+	}
+}
+
+func TestMemoryCacheCopiesMutableData(t *testing.T) {
+	cache := new(MemoryCache)
+	entry := CacheEnvelope{
+		NormalizedResult: json.RawMessage(`{"value":1}`),
+		Provenance:       CacheProvenance{Details: map[string]string{"source": "original"}},
+	}
+	if err := cache.Set(context.Background(), "key", entry); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	entry.NormalizedResult[2] = 'X'
+	entry.Provenance.Details["source"] = "changed"
+
+	stored, found, err := cache.Get(context.Background(), "key")
+	if err != nil || !found {
+		t.Fatalf("Get() = found %t, error %v", found, err)
+	}
+	if string(stored.NormalizedResult) != `{"value":1}` || stored.Provenance.Details["source"] != "original" {
+		t.Fatalf("stored entry mutated through caller: %+v", stored)
+	}
+
+	stored.NormalizedResult[2] = 'Y'
+	stored.Provenance.Details["source"] = "changed again"
+	storedAgain, _, _ := cache.Get(context.Background(), "key")
+	if string(storedAgain.NormalizedResult) != `{"value":1}` || storedAgain.Provenance.Details["source"] != "original" {
+		t.Fatalf("stored entry mutated through Get result: %+v", storedAgain)
+	}
+}
+
+func TestNewCacheCoordinatorRequiresPerSourcePolicy(t *testing.T) {
+	_, err := NewCacheCoordinator(CacheCoordinatorConfig{Cache: NewMemoryCache()})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("NewCacheCoordinator() error = %v, want ErrInvalidInput", err)
+	}
+
+	coordinator := testCacheCoordinator(t, NewMemoryCache(), &fakeCacheClock{now: cacheTestTime})
+	_, err = coordinator.Lookup(context.Background(), CacheRequest{Key: testCacheKey("unconfigured"), Policy: CachePolicyReadThrough}, successfulCacheFetch(`{"ok":true}`))
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("Lookup() error = %v, want ErrInvalidInput", err)
+	}
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -577,6 +577,49 @@ func TestCacheCoordinatorCoalescesConcurrentMisses(t *testing.T) {
 	}
 }
 
+func TestCompletedCacheCallHonorsWaitingContext(t *testing.T) {
+	tests := []struct {
+		name      string
+		context   func() context.Context
+		wantError error
+	}{
+		{
+			name: "canceled",
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantError: ErrCanceled,
+		},
+		{
+			name: "deadline exceeded",
+			context: func() context.Context {
+				ctx, cancel := context.WithDeadline(context.Background(), cacheTestTime.Add(-time.Second))
+				t.Cleanup(cancel)
+				return ctx
+			},
+			wantError: ErrTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			call := &cacheCall{
+				result: CacheLookupResult{State: CacheStateHit},
+				err:    errors.New("leader result must not escape"),
+			}
+			result, err := completedCacheCall(test.context(), call)
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("completedCacheCall() error = %v, want %v", err, test.wantError)
+			}
+			if !result.Coalesced || result.State != "" {
+				t.Fatalf("completedCacheCall() result = %+v, want canceled coalesced result", result)
+			}
+		})
+	}
+}
+
 func TestMemoryCacheCopiesMutableData(t *testing.T) {
 	cache := new(MemoryCache)
 	entry := CacheEnvelope{

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ the released API. These guides route readers to the material for their task.
 | --- | --- | --- |
 | Go application developer | [Project README](../README.md) | [Go package documentation](https://pkg.go.dev/github.com/georgestarcher/pwhois) |
 | AI coding assistant integrating the module | [Consumer-agent integration guide](consumer-agent-guide.md) | README usage and the exact version selected in `go.mod` |
+| Application cache implementer | [Cache contract guide](cache-contract.md) | `Cache`, `CacheEnvelope`, and `CacheCoordinator` package documentation |
 | Repository maintainer | [Maintainer guide](../AGENTS.md) | Deterministic tests and the open repository issues |
 
 ## Current validation

--- a/docs/cache-contract.md
+++ b/docs/cache-contract.md
@@ -1,0 +1,148 @@
+# Source-aware cache contract
+
+The cache API separates three responsibilities:
+
+1. A calling application performs one context-aware provider fetch and returns
+   normalized JSON plus non-sensitive provenance.
+2. A `Cache` implementation stores and retrieves versioned `CacheEnvelope`
+   values.
+3. `CacheCoordinator` applies source-specific freshness policy and coalesces
+   concurrent fetches for the same canonical key.
+
+This is cache infrastructure, not a replacement high-level PWHOIS client. The
+existing channel-based lookup methods continue to require a caller-owned
+connection. Context-aware high-level lookup work remains tracked in issue #33.
+
+## Canonical keys and envelopes
+
+Build a `CacheKeySpec` with all values that can affect the meaning or shape of
+a result:
+
+- source/provider identity;
+- endpoint and protocol;
+- the provider-specific normalized query;
+- behavior-changing options;
+- parser version; and
+- normalized result schema version.
+
+`CanonicalCacheKey` sorts options and hashes a versioned representation. The
+source remains visible in the key prefix for cache operations, while the
+digest prevents delimiter ambiguity. The same query against a different
+source, endpoint, option set, parser, or schema produces a different key.
+
+Every stored `CacheEnvelope` records that key contract, fetch and expiry times,
+normalized JSON, a stable provider error class when applicable, and
+provenance. The complete serialized envelope is bounded by `MaxEntryBytes`;
+the default is `DefaultMaxResponseBytes` (8 MiB). The envelope deliberately has
+no raw-response field.
+
+## Source policies
+
+Every configured source requires its own `SourceCachePolicy`; the coordinator
+has no global TTL fallback:
+
+| Field | Use |
+| --- | --- |
+| `SuccessTTL` | Fresh lifetime for a normalized successful result; must be positive. |
+| `NoRecordsTTL` | Negative-cache lifetime for `ErrNoRecords`; zero disables it. |
+| `RateLimitedTTL` | Cache lifetime for `ErrRateLimited`; zero disables it. |
+| `MaxStale` | Maximum time after expiry that a successful result may be returned by stale-if-error; zero disables fallback. |
+
+Connection, timeout, cancellation, malformed-response, oversized-response,
+invalid-input, and unknown errors are not cached. Stale-if-error may use a
+successful stale result for a provider timeout, but does not hide cancellation
+or deadline expiry of the caller's context. It never falls back to a stale
+negative or rate-limit entry.
+
+## Lookup policies
+
+| Policy | Cache read | Provider fetch | Cache write |
+| --- | --- | --- | --- |
+| `CachePolicyBypass` | Never | Always | Never |
+| `CachePolicyReadThrough` | Return a fresh hit | On miss or stale entry | Successful and configured negative/rate-limit results |
+| `CachePolicyRefresh` | Never | Always | Successful and configured negative/rate-limit results |
+| `CachePolicyFreshOnly` | Return only a fresh hit | Never | Never |
+| `CachePolicyStaleIfError` | Return a fresh hit | On miss or stale entry | Same as read-through unless bounded stale data is used |
+
+Fresh-only returns `ErrCacheMiss` or `ErrCacheStale`. A bounded stale fallback
+returns no top-level error because the requested fallback succeeded, but sets
+`CacheLookupResult.Stale` and `RefreshErrorClass`. Applications that require a
+live result must reject stale state explicitly.
+
+Backend read/write failures are represented by `*CacheError` and
+`ErrCacheUnavailable`. When a provider result remains usable, it is returned
+with `CacheLookupResult.CacheError` set. This preserves useful provider data
+without disguising a cache outage as a provider result. A cached negative or
+rate-limit hit returns `*CachedProviderError`; use `errors.Is` with
+`ErrNoRecords` or `ErrRateLimited` as usual.
+
+If a valid provider result would make the serialized envelope exceed
+`MaxEntryBytes`, the result remains usable with `CacheStateProvider` while
+`CacheError` matches `ErrCacheEntryTooLarge`; the oversized value is not sent
+to the backend.
+
+## Example
+
+The fetch callback below is intentionally application-owned. It stands in for
+a context-aware provider operation; it must not be implemented by abandoning a
+legacy lookup goroutine when its context is canceled.
+
+```go
+cache := pwhois.NewMemoryCache()
+coordinator, err := pwhois.NewCacheCoordinator(pwhois.CacheCoordinatorConfig{
+	Cache: cache,
+	SourcePolicies: map[string]pwhois.SourceCachePolicy{
+		"pwhois": {
+			SuccessTTL:     6 * time.Hour,
+			NoRecordsTTL:   10 * time.Minute,
+			RateLimitedTTL: time.Minute,
+			MaxStale:       30 * time.Minute,
+		},
+	},
+})
+if err != nil {
+	return err
+}
+
+request := pwhois.CacheRequest{
+	Policy: pwhois.CachePolicyReadThrough,
+	Key: pwhois.CacheKeySpec{
+		Source:              "pwhois",
+		Endpoint:            "whois.pwhois.org:43",
+		Protocol:            "pwhois",
+		NormalizedQuery:     "192.0.2.1",
+		Options:             map[string]string{"lookup": "ip"},
+		ParserVersion:       "ip-v1",
+		ResultSchemaVersion: "whois-v1",
+	},
+}
+
+result, err := coordinator.Lookup(ctx, request, fetchNormalizedIP)
+if err != nil {
+	return err
+}
+if result.CacheError != nil {
+	// Report cache health separately from the provider result.
+}
+if result.Stale {
+	// Apply the application's policy for bounded stale data.
+}
+useNormalizedJSON(result.Envelope.NormalizedResult)
+```
+
+## Backend requirements
+
+A `Cache` backend must:
+
+- honor context cancellation;
+- treat a missing key as `found=false` rather than fabricating a provider
+  error;
+- preserve the complete envelope;
+- avoid logging or retaining normalized results in error text;
+- apply its own capacity/eviction controls; and
+- be safe for its documented concurrency model.
+
+`MemoryCache` is concurrency-safe and copies mutable JSON and provenance maps
+on reads and writes. It is intentionally process-local and non-persistent.
+Distributed stampede protection is a backend/gateway concern; the coordinator
+only coalesces identical in-flight fetches inside one process.

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -93,6 +93,22 @@ Handle connection, write, read, rate-limit, and parser errors as normal
 application outcomes. Do not silently retry rate-limit errors, share one
 connection among unrelated lookups, or treat a partial result as successful.
 
+## Optional cache orchestration
+
+`CacheCoordinator` is a building block for an application's future
+context-aware lookup layer. It does not automatically wrap `LookupIP`,
+`LookupRouteView`, `LookupRegistry`, or `LookupNetblock`, and it does not change
+their caller-owned connection lifecycle. Do not introduce a goroutine around a
+legacy lookup merely to make it fit the coordinator; use the high-level API
+tracked in issue #33 when it becomes available, or supply an application-owned
+context-aware fetch operation.
+
+If the application uses this cache contract, read the
+[cache contract guide](cache-contract.md). In particular, configure a policy
+for each source, version parser/result schemas in the key, inspect
+`CacheLookupResult.CacheError` and stale metadata, and never put a raw provider
+response in `NormalizedResult`.
+
 ## Server and data boundaries
 
 `SetDefaultValues` configures `whois.pwhois.org:43`, the tested default. A


### PR DESCRIPTION
## Summary

- add a source-aware `Cache` interface, versioned `CacheEnvelope`, and deterministic canonical keys
- add bypass, read-through, refresh, fresh-only, and bounded stale-if-error coordination
- add source-specific success, negative, rate-limit, and stale policies plus in-process duplicate-fetch coalescing
- add a concurrency-safe `MemoryCache`, stable cache/provider error metadata, and complete-envelope size limits
- document the contract and its boundary from the current caller-owned connection API

## Impact

This establishes the cache foundation needed by the future context-aware lookup API without changing any existing PWHOIS lookup behavior. Cache failures remain separate from provider outcomes, and raw provider responses are not part of the stored contract.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`

Closes #48