### PR TITLE
Add deterministic local protocol harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ go vet ./...
 go build ./...
 ```
 
+The required test suite includes an IPv4 loopback-only scripted PWHOIS server
+that verifies the complete connect, exact request, response, orderly EOF, and
+caller-owned connection cleanup lifecycle for every supported lookup type.
+Malformed, truncated, rate-limited, oversized, and non-responsive server paths
+also use deterministic local fixtures.
+
 Live integration tests use `whois.pwhois.org:43` and must be requested explicitly:
 
 ```shell

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,5 +26,9 @@ Live checks use the public default PWHOIS server and are opt-in:
 go test -tags=integration ./...
 ```
 
+Required protocol coverage uses only a scripted IPv4 loopback server. It
+exercises real TCP connect, request, response, EOF, timeout, and caller cleanup
+behavior without depending on a public service.
+
 The repository does not yet have a canonical documentation-validation command;
 that work is tracked in issue #28.

--- a/pwhois_deadline_test.go
+++ b/pwhois_deadline_test.go
@@ -7,50 +7,6 @@ import (
 	"time"
 )
 
-func connectStalledServer(t *testing.T) net.Conn {
-	t.Helper()
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-
-	accepted := make(chan net.Conn, 1)
-	done := make(chan struct{})
-	go func() {
-		connection, err := listener.Accept()
-		if err == nil {
-			accepted <- connection
-			<-done
-			connection.Close()
-		}
-	}()
-
-	connection, err := net.Dial("tcp", listener.Addr().String())
-	if err != nil {
-		listener.Close()
-		close(done)
-		t.Fatalf("dial stalled server: %v", err)
-	}
-
-	select {
-	case <-accepted:
-	case <-time.After(time.Second):
-		connection.Close()
-		listener.Close()
-		close(done)
-		t.Fatal("stalled server did not accept connection")
-	}
-
-	t.Cleanup(func() {
-		connection.Close()
-		listener.Close()
-		close(done)
-	})
-
-	return connection
-}
-
 func assertTimeout(t *testing.T, err error) {
 	t.Helper()
 
@@ -68,41 +24,46 @@ func assertTimeout(t *testing.T, err error) {
 }
 
 func TestLookupDeadlineTimesOutStalledServers(t *testing.T) {
-	const timeout = 25 * time.Millisecond
+	const timeout = 100 * time.Millisecond
 
 	tests := []struct {
-		name   string
-		lookup func(WhoisServer) error
+		name    string
+		request string
+		lookup  func(WhoisServer) error
 	}{
 		{
-			name: "IP",
+			name:    "IP",
+			request: "app=\"GO pwhois Module\"\n192.0.2.1\n",
 			lookup: func(server WhoisServer) error {
 				responses := make(chan IpLookupResponse, 1)
-				server.LookupIP("8.8.8.8\n", responses)
+				server.LookupIP("app=\"GO pwhois Module\"\n192.0.2.1\n", responses)
 				return (<-responses).Error
 			},
 		},
 		{
-			name: "RouteView",
+			name:    "RouteView",
+			request: "app=\"GO pwhois Module\" routeview source-as=64500\n",
 			lookup: func(server WhoisServer) error {
 				responses := make(chan BGPLookupResponse, 1)
-				server.LookupRouteView("3356", "routeview source-as=3356\n", responses)
+				server.LookupRouteView("64500", "app=\"GO pwhois Module\" routeview source-as=64500\n", responses)
 				return (<-responses).Error
 			},
 		},
 		{
-			name: "Registry",
+			name:    "Registry",
+			request: "app=\"GO pwhois Module\" registry source-as=64500\n",
 			lookup: func(server WhoisServer) error {
 				responses := make(chan RegistryLookupResponse, 1)
-				server.LookupRegistry("3356", "registry source-as=3356\n", responses)
+				server.LookupRegistry("64500", "app=\"GO pwhois Module\" registry source-as=64500\n", responses)
 				return (<-responses).Error
 			},
 		},
 		{
-			name: "Netblock",
+			name:    "Netblock",
+			request: "app=\"GO pwhois Module\" netblock source-as=64500\n",
 			lookup: func(server WhoisServer) error {
 				responses := make(chan NetblockLookupResponse, 1)
-				server.LookupNetblock("3356", "netblock source-as=3356\n", responses)
+				server.LookupNetblock("64500", "app=\"GO pwhois Module\" netblock source-as=64500\n", responses)
 				return (<-responses).Error
 			},
 		},
@@ -110,8 +71,13 @@ func TestLookupDeadlineTimesOutStalledServers(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			server := WhoisServer{Connection: connectStalledServer(t), Timeout: timeout}
-			assertTimeout(t, test.lookup(server))
+			server, results := connectLoopbackProtocolServer(t, loopbackProtocolScript{
+				expectedRequest: test.request,
+				noResponse:      true,
+			})
+			server.Timeout = timeout
+			assertTimeout(t, test.lookup(*server))
+			closeAndVerifyLoopbackProtocol(t, server, results, test.request)
 		})
 	}
 }

--- a/pwhois_error_test.go
+++ b/pwhois_error_test.go
@@ -1,10 +1,8 @@
 package pwhois
 
 import (
-	"bufio"
 	"context"
 	"errors"
-	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -24,53 +22,59 @@ func (connection deadlineErrorConnection) SetDeadline(time.Time) error {
 func lookupErrorCases() []struct {
 	name      string
 	operation string
+	query     string
 	lookup    func(WhoisServer) error
 } {
 	return []struct {
 		name      string
 		operation string
+		query     string
 		lookup    func(WhoisServer) error
 	}{
 		{
 			name:      "IP",
 			operation: "lookup IP",
+			query:     "app=\"GO pwhois Module\"\n192.0.2.1\n",
 			lookup: func(server WhoisServer) error {
 				responses := make(chan IpLookupResponse, 1)
-				server.LookupIP("192.0.2.1\n", responses)
+				server.LookupIP("app=\"GO pwhois Module\"\n192.0.2.1\n", responses)
 				return (<-responses).Error
 			},
 		},
 		{
 			name:      "RouteView",
 			operation: "lookup RouteView",
+			query:     "app=\"GO pwhois Module\" routeview source-as=64500\n",
 			lookup: func(server WhoisServer) error {
 				responses := make(chan BGPLookupResponse, 1)
-				server.LookupRouteView("64500", "routeview source-as=64500\n", responses)
+				server.LookupRouteView("64500", "app=\"GO pwhois Module\" routeview source-as=64500\n", responses)
 				return (<-responses).Error
 			},
 		},
 		{
 			name:      "Registry",
 			operation: "lookup registry",
+			query:     "app=\"GO pwhois Module\" registry source-as=64500\n",
 			lookup: func(server WhoisServer) error {
 				responses := make(chan RegistryLookupResponse, 1)
-				server.LookupRegistry("64500", "registry source-as=64500\n", responses)
+				server.LookupRegistry("64500", "app=\"GO pwhois Module\" registry source-as=64500\n", responses)
 				return (<-responses).Error
 			},
 		},
 		{
 			name:      "Netblock",
 			operation: "lookup netblock",
+			query:     "app=\"GO pwhois Module\" netblock source-as=64500\n",
 			lookup: func(server WhoisServer) error {
 				responses := make(chan NetblockLookupResponse, 1)
-				server.LookupNetblock("64500", "netblock source-as=64500\n", responses)
+				server.LookupNetblock("64500", "app=\"GO pwhois Module\" netblock source-as=64500\n", responses)
 				return (<-responses).Error
 			},
 		},
 	}
 }
 
-func assertOperationError(t *testing.T, err error, operation string) {
+func assertOperationError(t *testing.T, err error, operation, server string) {
 	t.Helper()
 
 	var operationError *OperationError
@@ -80,31 +84,29 @@ func assertOperationError(t *testing.T, err error, operation string) {
 	if operationError.Operation != operation {
 		t.Errorf("operation = %q, want %q", operationError.Operation, operation)
 	}
-	if operationError.Server != "test.pwhois.example:43" {
-		t.Errorf("server = %q, want test.pwhois.example:43", operationError.Server)
+	if operationError.Server != server {
+		t.Errorf("server = %q, want %q", operationError.Server, server)
 	}
 }
 
-func lookupErrorFromResponse(t *testing.T, lookup func(WhoisServer) error, response string, maximumResponseBytes int64) error {
+func lookupErrorFromResponse(t *testing.T, lookupCase struct {
+	name      string
+	operation string
+	query     string
+	lookup    func(WhoisServer) error
+}, response string, maximumResponseBytes int64) (error, string) {
 	t.Helper()
 
-	connection, done := connectScriptedResponseServer(t, func(connection net.Conn) error {
-		if _, err := bufio.NewReader(connection).ReadString('\n'); err != nil {
-			return err
-		}
-		_, err := io.WriteString(connection, response)
-		return err
+	server, results := connectLoopbackProtocolServer(t, loopbackProtocolScript{
+		expectedRequest: lookupCase.query,
+		responseChunks:  []string{response},
 	})
-
-	server := WhoisServer{
-		Server:           "test.pwhois.example",
-		Port:             43,
-		Connection:       connection,
-		MaxResponseBytes: maximumResponseBytes,
+	if maximumResponseBytes > 0 {
+		server.MaxResponseBytes = maximumResponseBytes
 	}
-	err := lookup(server)
-	waitForScriptedServer(t, done)
-	return err
+	err := lookupCase.lookup(*server)
+	closeAndVerifyLoopbackProtocol(t, server, results, lookupCase.query)
+	return err, server.ServerAddressString()
 }
 
 func TestLookupErrorClassesAreConsistent(t *testing.T) {
@@ -122,34 +124,34 @@ func TestLookupErrorClassesAreConsistent(t *testing.T) {
 			if !errors.Is(err, ErrConnection) {
 				t.Fatalf("error = %v, want ErrConnection", err)
 			}
-			assertOperationError(t, err, lookupCase.operation)
+			assertOperationError(t, err, lookupCase.operation, "test.pwhois.example:43")
 		})
 
 		t.Run(lookupCase.name+"/rate limited", func(t *testing.T) {
-			err := lookupErrorFromResponse(t, lookupCase.lookup, "Error: query limit exceeded\n"+secret, 0)
+			err, endpoint := lookupErrorFromResponse(t, lookupCase, "Error: query limit exceeded\n"+secret, 0)
 			if !errors.Is(err, ErrRateLimited) {
 				t.Fatalf("error = %v, want ErrRateLimited", err)
 			}
 			if strings.Contains(err.Error(), secret) {
 				t.Fatal("rate-limit error exposed remote response content")
 			}
-			assertOperationError(t, err, lookupCase.operation)
+			assertOperationError(t, err, lookupCase.operation, endpoint)
 		})
 
 		t.Run(lookupCase.name+"/no records", func(t *testing.T) {
-			err := lookupErrorFromResponse(t, lookupCase.lookup, "", 0)
+			err, endpoint := lookupErrorFromResponse(t, lookupCase, "", 0)
 			if !errors.Is(err, ErrNoRecords) {
 				t.Fatalf("error = %v, want ErrNoRecords", err)
 			}
-			assertOperationError(t, err, lookupCase.operation)
+			assertOperationError(t, err, lookupCase.operation, endpoint)
 		})
 
 		t.Run(lookupCase.name+"/malformed response", func(t *testing.T) {
-			err := lookupErrorFromResponse(t, lookupCase.lookup, malformedResponses[lookupCase.name], 0)
+			err, endpoint := lookupErrorFromResponse(t, lookupCase, malformedResponses[lookupCase.name], 0)
 			if !errors.Is(err, ErrMalformedResponse) {
 				t.Fatalf("error = %v, want ErrMalformedResponse", err)
 			}
-			assertOperationError(t, err, lookupCase.operation)
+			assertOperationError(t, err, lookupCase.operation, endpoint)
 		})
 	}
 }
@@ -170,7 +172,7 @@ func TestLookupCancellationErrorPreservesClass(t *testing.T) {
 	if !errors.Is(err, ErrCanceled) || !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want ErrCanceled and context.Canceled", err)
 	}
-	assertOperationError(t, err, "lookup IP")
+	assertOperationError(t, err, "lookup IP", "test.pwhois.example:43")
 }
 
 func TestConnectErrorPreservesTransportCause(t *testing.T) {
@@ -226,9 +228,9 @@ func TestNetblockServerErrorDoesNotExposeRemoteContent(t *testing.T) {
 
 func TestResponseTooLargeIncludesOperationContext(t *testing.T) {
 	lookupCase := lookupErrorCases()[0]
-	err := lookupErrorFromResponse(t, lookupCase.lookup, strings.Repeat("x", 65), 64)
+	err, endpoint := lookupErrorFromResponse(t, lookupCase, strings.Repeat("x", 65), 64)
 	if !errors.Is(err, ErrResponseTooLarge) {
 		t.Fatalf("error = %v, want ErrResponseTooLarge", err)
 	}
-	assertOperationError(t, err, lookupCase.operation)
+	assertOperationError(t, err, lookupCase.operation, endpoint)
 }

--- a/pwhois_protocol_test.go
+++ b/pwhois_protocol_test.go
@@ -1,0 +1,363 @@
+package pwhois
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+type loopbackProtocolScript struct {
+	expectedRequest string
+	responseChunks  []string
+	noResponse      bool
+}
+
+type loopbackProtocolResult struct {
+	request      string
+	clientClosed bool
+	err          error
+}
+
+// connectLoopbackProtocolServer starts a one-connection, IPv4 loopback-only
+// PWHOIS test server and connects through WhoisServer.Connect. The server
+// reads the exact scripted request, optionally returns response chunks, sends
+// orderly EOF with CloseWrite, and then verifies that the caller closes its
+// side of the connection.
+func connectLoopbackProtocolServer(t *testing.T, script loopbackProtocolScript) (*WhoisServer, <-chan loopbackProtocolResult) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on loopback: %v", err)
+	}
+	results := make(chan loopbackProtocolResult, 1)
+
+	go func() {
+		result := loopbackProtocolResult{}
+		defer func() {
+			results <- result
+		}()
+		defer listener.Close()
+
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			result.err = fmt.Errorf("accept loopback connection: %w", acceptErr)
+			return
+		}
+		defer connection.Close()
+		if deadlineErr := connection.SetDeadline(time.Now().Add(3 * time.Second)); deadlineErr != nil {
+			result.err = fmt.Errorf("set loopback deadline: %w", deadlineErr)
+			return
+		}
+
+		request := make([]byte, len(script.expectedRequest))
+		if _, readErr := io.ReadFull(connection, request); readErr != nil {
+			result.err = fmt.Errorf("read scripted request: %w", readErr)
+			return
+		}
+		result.request = string(request)
+
+		if !script.noResponse {
+			for _, chunk := range script.responseChunks {
+				if _, writeErr := io.WriteString(connection, chunk); writeErr != nil {
+					result.err = fmt.Errorf("write scripted response: %w", writeErr)
+					return
+				}
+			}
+
+			tcpConnection, ok := connection.(*net.TCPConn)
+			if !ok {
+				result.err = fmt.Errorf("loopback connection type = %T, want *net.TCPConn", connection)
+				return
+			}
+			if closeErr := tcpConnection.CloseWrite(); closeErr != nil {
+				result.err = fmt.Errorf("send orderly EOF: %w", closeErr)
+				return
+			}
+		}
+
+		buffer := make([]byte, 1)
+		read, readErr := connection.Read(buffer)
+		if read != 0 {
+			result.err = fmt.Errorf("received %d unexpected bytes after scripted request", read)
+			return
+		}
+		if !errors.Is(readErr, io.EOF) {
+			result.err = fmt.Errorf("wait for client close: %w", readErr)
+			return
+		}
+		result.clientClosed = true
+	}()
+
+	address := listener.Addr().(*net.TCPAddr)
+	server := &WhoisServer{
+		Server:           address.IP.String(),
+		Port:             address.Port,
+		BatchMaxSize:     500,
+		Timeout:          2 * time.Second,
+		MaxResponseBytes: DefaultMaxResponseBytes,
+	}
+	if err := server.Connect(); err != nil {
+		listener.Close()
+		t.Fatalf("connect to loopback server: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if server.Connection != nil {
+			_ = server.Connection.Close()
+		}
+		_ = listener.Close()
+	})
+	return server, results
+}
+
+func closeAndVerifyLoopbackProtocol(t *testing.T, server *WhoisServer, results <-chan loopbackProtocolResult, expectedRequest string) {
+	t.Helper()
+
+	if err := server.Connection.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+		t.Errorf("close loopback client: %v", err)
+	}
+	select {
+	case result := <-results:
+		if result.err != nil {
+			t.Fatalf("loopback protocol server: %v", result.err)
+		}
+		if result.request != expectedRequest {
+			t.Errorf("wire request = %q, want %q", result.request, expectedRequest)
+		}
+		if !result.clientClosed {
+			t.Error("loopback server did not observe client connection cleanup")
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("loopback protocol server did not finish")
+	}
+}
+
+func TestLoopbackProtocolSuccessfulLookups(t *testing.T) {
+	const (
+		ipSingleRequest = "app=\"GO pwhois Module\"\n192.0.2.1\n"
+		ipBatchRequest  = "app=\"GO pwhois Module\"\nbegin\n192.0.2.1\n198.51.100.2\nend\n"
+		routeRequest    = "app=\"GO pwhois Module\" routeview source-as=64500\n"
+		registryRequest = "app=\"GO pwhois Module\" registry source-as=64500\n"
+		netblockRequest = "app=\"GO pwhois Module\" netblock source-as=64500\n"
+	)
+
+	tests := []struct {
+		name            string
+		expectedRequest string
+		responseChunks  []string
+		format          func(*WhoisServer) (string, error)
+		lookup          func(WhoisServer, string) (any, error)
+		check           func(*testing.T, any)
+	}{
+		{
+			name:            "single IP",
+			expectedRequest: ipSingleRequest,
+			responseChunks: []string{
+				"IP: 192.0.2.1\nOrigin-AS: 64500\n",
+				"Org-Name: Example Network\nCountry-Code: ZZ",
+			},
+			format: func(server *WhoisServer) (string, error) {
+				return server.FormatIpQuery([]string{"192.0.2.1"})
+			},
+			lookup: func(server WhoisServer, query string) (any, error) {
+				responses := make(chan IpLookupResponse, 1)
+				server.LookupIP(query, responses)
+				response := <-responses
+				return response.Response, response.Error
+			},
+			check: func(t *testing.T, value any) {
+				records := value.([]WhoIs)
+				if len(records) != 1 || records[0].IP != "192.0.2.1" || records[0].OriginAS != "64500" {
+					t.Fatalf("IP response = %+v", records)
+				}
+			},
+		},
+		{
+			name:            "batch IP",
+			expectedRequest: ipBatchRequest,
+			responseChunks: []string{
+				"IP: 192.0.2.1\nOrigin-AS: 64500\nOrg-Name: Example One\n\n",
+				"IP: 198.51.100.2\nOrigin-AS: 64501\nOrg-Name: Example Two",
+			},
+			format: func(server *WhoisServer) (string, error) {
+				return server.FormatIpQuery([]string{"192.0.2.1", "198.51.100.2", "192.0.2.1"})
+			},
+			lookup: func(server WhoisServer, query string) (any, error) {
+				responses := make(chan IpLookupResponse, 1)
+				server.LookupIP(query, responses)
+				response := <-responses
+				return response.Response, response.Error
+			},
+			check: func(t *testing.T, value any) {
+				records := value.([]WhoIs)
+				if len(records) != 2 || records[0].IP != "192.0.2.1" || records[1].IP != "198.51.100.2" {
+					t.Fatalf("batch IP response = %+v", records)
+				}
+			},
+		},
+		{
+			name:            "RouteView",
+			expectedRequest: routeRequest,
+			responseChunks: []string{
+				"Origin-AS: 64500\n",
+				"*> 192.0.2.0/24 | Jul 18 2026 00:00:04 | Jul 18 2026 00:00:04 | May 28 2026 06:56:01 | 192.0.2.254 | 64501 64500",
+			},
+			format: func(server *WhoisServer) (string, error) {
+				return server.FormatRouteViewQuery("AS64500")
+			},
+			lookup: func(server WhoisServer, query string) (any, error) {
+				responses := make(chan BGPLookupResponse, 1)
+				server.LookupRouteView("64500", query, responses)
+				response := <-responses
+				return response.Response, response.Error
+			},
+			check: func(t *testing.T, value any) {
+				routes := value.(BGPRoutes)
+				if routes.Asn != "64500" || len(routes.Routes) != 1 || routes.Routes[0].Prefix != "192.0.2.0/24" {
+					t.Fatalf("RouteView response = %+v", routes)
+				}
+			},
+		},
+		{
+			name:            "registry",
+			expectedRequest: registryRequest,
+			responseChunks: []string{
+				"Org-Record: TEST-ORG\nOrg-ID: TEST\nOrg-Name: Example Registry Organization\n",
+				"Can-Allocate: 1\nSource: TEST\nPostal-Code: 00000\nCountry-Code: ZZ",
+			},
+			format: func(server *WhoisServer) (string, error) {
+				return server.FormatRegistryQuery("AS64500")
+			},
+			lookup: func(server WhoisServer, query string) (any, error) {
+				responses := make(chan RegistryLookupResponse, 1)
+				server.LookupRegistry("64500", query, responses)
+				response := <-responses
+				return response.Response, response.Error
+			},
+			check: func(t *testing.T, value any) {
+				record := value.(RegistryRecord)
+				if record.Asn != "64500" || record.Registry.OrgID != "TEST" || !record.Registry.CanAllocate {
+					t.Fatalf("registry response = %+v", record)
+				}
+			},
+		},
+		{
+			name:            "netblock",
+			expectedRequest: netblockRequest,
+			responseChunks: []string{
+				"Origin-AS: 64500\nAS: 64500\nAS-Source: TEST\nOrg: 1\nOrg-ID: TEST\nOrg-Name: Example Networks\nOrg-Source: TEST\n",
+				"*> 192.0.2.0 - 192.0.2.255 | EXAMPLE-NET | reassignment | 2019-05-25 | 2019-09-25 | Jun 28 2019 16:53:01 | Jul 18 2026 03:19:32 | TEST",
+			},
+			format: func(server *WhoisServer) (string, error) {
+				return server.FormatNetblockQuery("AS64500")
+			},
+			lookup: func(server WhoisServer, query string) (any, error) {
+				responses := make(chan NetblockLookupResponse, 1)
+				server.LookupNetblock("64500", query, responses)
+				response := <-responses
+				return response.Response, response.Error
+			},
+			check: func(t *testing.T, value any) {
+				record := value.(NetblockRecord)
+				if record.Asn != "64500" || record.OrgName != "Example Networks" || len(record.Netblocks) != 1 {
+					t.Fatalf("netblock response = %+v", record)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, results := connectLoopbackProtocolServer(t, loopbackProtocolScript{
+				expectedRequest: test.expectedRequest,
+				responseChunks:  test.responseChunks,
+			})
+
+			query, err := test.format(server)
+			if err != nil {
+				t.Fatalf("format query: %v", err)
+			}
+			if query != test.expectedRequest {
+				t.Fatalf("formatted query = %q, want %q", query, test.expectedRequest)
+			}
+			response, err := test.lookup(*server, query)
+			if err != nil {
+				t.Fatalf("lookup: %v", err)
+			}
+			test.check(t, response)
+			closeAndVerifyLoopbackProtocol(t, server, results, test.expectedRequest)
+		})
+	}
+}
+
+func TestLoopbackProtocolTruncatedResponsesFailSafely(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  string
+		response string
+		lookup   func(WhoisServer) error
+	}{
+		{
+			name:     "IP",
+			request:  "app=\"GO pwhois Module\"\n192.0.2.1\n",
+			response: "IP: 192.0.2.1\nLatitude: 1e",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan IpLookupResponse, 1)
+				server.LookupIP("app=\"GO pwhois Module\"\n192.0.2.1\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name:     "RouteView",
+			request:  "app=\"GO pwhois Module\" routeview source-as=64500\n",
+			response: "*> 192.0.2.0/24 | Jul 18",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan BGPLookupResponse, 1)
+				server.LookupRouteView("64500", "app=\"GO pwhois Module\" routeview source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name:     "registry",
+			request:  "app=\"GO pwhois Module\" registry source-as=64500\n",
+			response: "Org-ID: TEST\nCan-Allocate: not-",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan RegistryLookupResponse, 1)
+				server.LookupRegistry("64500", "app=\"GO pwhois Module\" registry source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+		{
+			name:     "netblock",
+			request:  "app=\"GO pwhois Module\" netblock source-as=64500\n",
+			response: "Origin-AS: 64500\n*> 192.0.2.0 -",
+			lookup: func(server WhoisServer) error {
+				responses := make(chan NetblockLookupResponse, 1)
+				server.LookupNetblock("64500", "app=\"GO pwhois Module\" netblock source-as=64500\n", responses)
+				return (<-responses).Error
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, results := connectLoopbackProtocolServer(t, loopbackProtocolScript{
+				expectedRequest: test.request,
+				responseChunks:  []string{test.response},
+			})
+			err := test.lookup(*server)
+			if !errors.Is(err, ErrMalformedResponse) {
+				t.Fatalf("truncated lookup error = %v, want ErrMalformedResponse", err)
+			}
+			if strings.Contains(err.Error(), test.response) {
+				t.Fatal("truncated lookup error exposed remote response content")
+			}
+			closeAndVerifyLoopbackProtocol(t, server, results, test.request)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add a reusable IPv4 loopback-only scripted PWHOIS server that exercises `WhoisServer.Connect` and verifies exact request bytes
- cover successful single and batch IP, RouteView, registry, and netblock exchanges through orderly EOF
- move timeout and stable-error scenarios onto the real connect/write/read/caller-close lifecycle
- add deterministic truncated-response coverage for every lookup and document the required local protocol harness

## Impact

The required test suite now verifies real TCP lifecycle and connection cleanup without contacting public PWHOIS services. Fixtures use reserved addresses, synthetic ASNs, and synthetic organization data.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- focused loopback/error suite repeated 20 times

Closes #30