### PR TITLE
Add context-aware high-level lookup API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,16 @@ released module to another application must start with
 
 ## Network behavior
 
-- A caller owns `WhoisServer.Connection`: call `Connect`, use one connection
-  for one lookup, check the returned response error, and close the connection.
+- Prefer the context-aware high-level lookup methods. Each call owns one
+  connection from dial through close. A configured `WhoisServer` is safe for
+  concurrent high-level calls only while its fields and custom `DialContext`
+  hook remain unchanged.
+- The deprecated low-level API remains a caller-owned lifecycle:
+  call `Connect`, use one connection for one lookup, check the returned response
+  error, and close `WhoisServer.Connection`.
 - `WhoisServer.Timeout` bounds connection establishment and the full lookup
-  write/read exchange. Its zero value uses the five-second default. The current
-  API has no context-aware high-level lookup; do not invent one. See #33 for
-  that future API work.
+  write/read exchange. Its zero value uses the five-second default. A shorter
+  context deadline takes precedence for high-level calls.
 - Respect server rate limits. Rate-limit responses and network errors are
   normal caller-visible outcomes, not conditions to hide with automatic retry.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ released module to another application must start with
 
 - Prefer the context-aware high-level lookup methods. Each call owns one
   connection from dial through close. A configured `WhoisServer` is safe for
-  concurrent high-level calls only while its fields and custom `DialContext`
-  hook remain unchanged.
+  concurrent high-level calls only while its fields and custom `ContextDialer`
+  remain unchanged.
 - The deprecated low-level API remains a caller-owned lifecycle:
   call `Connect`, use one connection for one lookup, check the returned response
   error, and close `WhoisServer.Connection`.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,24 @@ go get github.com/georgestarcher/pwhois
 
 ## Usage
 
-Each lookup uses a TCP connection to a PWHOIS server. Close the connection when the lookup is complete. By default, connection establishment and the complete lookup exchange time out after five seconds; set `WhoisServer.Timeout` to use a different `time.Duration`. Responses are limited to 8 MiB by default; set `WhoisServer.MaxResponseBytes` to a positive byte count when an application needs a different bound. Batch IP lookups accept up to 500 addresses; callers should also respect the selected server's rate limits.
+The context-aware lookup methods format the query, establish a dedicated TCP
+connection, complete the exchange, parse the response, and close the connection
+before returning. The zero-value `WhoisServer` uses the documented defaults.
+By default, connection establishment and the complete lookup operation time out
+after five seconds; set `WhoisServer.Timeout` to use a different
+`time.Duration`. A shorter caller deadline takes precedence, and cancellation
+interrupts an in-progress dial, write, or read.
+
+Responses are limited to 8 MiB by default; set
+`WhoisServer.MaxResponseBytes` to a positive byte count when an application
+needs a different bound. Batch IP lookups accept up to 500 addresses. Callers
+should also respect the selected server's rate limits.
 
 ```go
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -36,41 +48,35 @@ import (
 )
 
 func main() {
-	server := new(pwhois.WhoisServer)
-	server.SetDefaultValues()
-
-	if err := server.Connect(); err != nil {
-		log.Fatal(err)
-	}
-	defer server.Connection.Close()
-
-	query, err := server.FormatIpQuery([]string{"8.8.8.8"})
+	server := pwhois.WhoisServer{}
+	records, err := server.LookupIPContext(
+		context.Background(),
+		[]string{"192.0.2.1"},
+	)
 	if err != nil {
-		log.Fatal(err)
-	}
-
-	responses := make(chan pwhois.IpLookupResponse, 1)
-	server.LookupIP(query, responses)
-	response := <-responses
-
-	if response.Error != nil {
-		if errors.Is(response.Error, pwhois.ErrRateLimited) {
+		if errors.Is(err, pwhois.ErrRateLimited) {
 			// Apply the calling application's rate-limit policy.
 		}
 		var operationError *pwhois.OperationError
-		if errors.As(response.Error, &operationError) {
+		if errors.As(err, &operationError) {
 			log.Printf("%s against %s failed", operationError.Operation, operationError.Server)
 		}
-		log.Fatal(response.Error)
+		log.Fatal(err)
 	}
 
-	for _, record := range response.Response {
+	for _, record := range records {
 		fmt.Printf("%s: AS%s (%s)\n", record.IP, record.OriginAS, record.OrgName)
 	}
 }
 ```
 
-The other supported lookup types follow the same pattern. Use a separate connected `WhoisServer` for each lookup.
+The other supported lookup types follow the same pattern. A configured
+`WhoisServer` may be shared by concurrent high-level calls as long as its
+fields—and any custom `DialContext` function—are not mutated while calls are
+running. Every call uses an independent connection. The older `Connect`,
+`Connection`, query-formatter, channel-response API remains available for
+compatibility but is deprecated for new integrations; callers using it must
+continue to use one connected server per lookup and close the connection.
 
 All four lookup methods enforce the same response-size limit before parsing.
 An over-limit response closes its connection and returns a
@@ -112,12 +118,11 @@ context-aware lookup orchestration. `CacheCoordinator` supports bypass,
 read-through, forced refresh, fresh-only, and bounded stale-if-error policies.
 It also coalesces concurrent misses for one canonical key within a process.
 
-The coordinator does **not** change the connection ownership or automatically
-wrap the four existing lookup methods. A calling application supplies a
-context-aware fetch function, a `Cache` backend, and an explicit
-`SourceCachePolicy` for every provider/source. This lets a later high-level
-lookup API use the same contract without making the current channel-based API
-silently retry or cache network operations.
+The coordinator does **not** automatically wrap the four high-level lookup
+methods. A calling application supplies a context-aware fetch function, a
+`Cache` backend, and an explicit `SourceCachePolicy` for every provider/source.
+This keeps caching and retry policy in the application rather than silently
+changing lookup behavior.
 
 Cache keys include the source, endpoint, protocol, normalized query, options,
 parser version, and result schema version. Stored `CacheEnvelope` values
@@ -133,12 +138,12 @@ AI coding assistants integrating this module should use the
 [consumer-agent integration guide](docs/consumer-agent-guide.md). Repository
 maintainers should use the [maintainer guide](AGENTS.md).
 
-| Lookup | Query formatter | Lookup method | Response type |
+| Lookup | Preferred high-level method | Result type |
 | --- | --- | --- | --- |
-| IP | `FormatIpQuery` | `LookupIP` | `IpLookupResponse` |
-| RouteView | `FormatRouteViewQuery` | `LookupRouteView` | `BGPLookupResponse` |
-| Registry | `FormatRegistryQuery` | `LookupRegistry` | `RegistryLookupResponse` |
-| Netblock | `FormatNetblockQuery` | `LookupNetblock` | `NetblockLookupResponse` |
+| IP | `LookupIPContext` | `[]WhoIs` |
+| RouteView | `LookupRouteViewContext` | `BGPRoutes` |
+| Registry | `LookupRegistryContext` | `RegistryRecord` |
+| Netblock | `LookupNetblockContext` | `NetblockRecord` |
 
 ## PWHOIS servers
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ func main() {
 
 The other supported lookup types follow the same pattern. A configured
 `WhoisServer` may be shared by concurrent high-level calls as long as its
-fields—and any custom `DialContext` function—are not mutated while calls are
+	fields—and any custom `Dialer`—are not mutated while calls are
 running. Every call uses an independent connection. The older `Connect`,
 `Connection`, query-formatter, channel-response API remains available for
 compatibility but is deprecated for new integrations; callers using it must
@@ -81,7 +81,7 @@ continue to use one connected server per lookup and close the connection.
 All four lookup methods enforce the same response-size limit before parsing.
 An over-limit response closes its connection and returns a
 `*pwhois.ResponseTooLargeError`; callers can detect the stable failure class
-with `errors.Is(response.Error, pwhois.ErrResponseTooLarge)`. The error reports
+with `errors.Is(err, pwhois.ErrResponseTooLarge)`. The error reports
 the configured limit but does not include remote response content. The 8 MiB
 default provides more than 16 KiB per result for a maximum 500-address IP
 batch. RouteView or netblock queries with unusually large legitimate results
@@ -89,8 +89,8 @@ may require a higher application-specific limit.
 
 ## Error handling
 
-Every formatter, `Connect`, and lookup response error uses a stable class that
-can be tested with `errors.Is`; error wording is not an API contract.
+Every formatter, connection, and lookup error uses a stable class that can be
+tested with `errors.Is`; error wording is not an API contract.
 
 | Error class | Meaning |
 | --- | --- |
@@ -161,7 +161,8 @@ go build ./...
 
 The required test suite includes an IPv4 loopback-only scripted PWHOIS server
 that verifies the complete connect, exact request, response, orderly EOF, and
-caller-owned connection cleanup lifecycle for every supported lookup type.
+connection cleanup lifecycle for every supported lookup type. It covers both
+automatic high-level cleanup and the deprecated caller-owned lifecycle.
 Malformed, truncated, rate-limited, oversized, and non-responsive server paths
 also use deterministic local fixtures.
 

--- a/docs/cache-contract.md
+++ b/docs/cache-contract.md
@@ -9,9 +9,13 @@ The cache API separates three responsibilities:
 3. `CacheCoordinator` applies source-specific freshness policy and coalesces
    concurrent fetches for the same canonical key.
 
-This is cache infrastructure, not a replacement high-level PWHOIS client. The
-existing channel-based lookup methods continue to require a caller-owned
-connection. Context-aware high-level lookup work remains tracked in issue #33.
+This is cache infrastructure, not an implicit wrapper around the high-level
+PWHOIS client. Applications may use `LookupIPContext`,
+`LookupRouteViewContext`, `LookupRegistryContext`, or
+`LookupNetblockContext` inside their context-aware fetch operation, but they
+must still select a source, cache policy, and normalized result explicitly.
+The deprecated channel-based lookup methods continue to require a caller-owned
+connection.
 
 ## Canonical keys and envelopes
 
@@ -83,9 +87,10 @@ to the backend.
 
 ## Example
 
-The fetch callback below is intentionally application-owned. It stands in for
-a context-aware provider operation; it must not be implemented by abandoning a
-legacy lookup goroutine when its context is canceled.
+The fetch callback below is intentionally application-owned. It can call one
+of the context-aware high-level lookup methods and normalize the typed result.
+It must not be implemented by abandoning a legacy lookup goroutine when its
+context is canceled.
 
 ```go
 cache := pwhois.NewMemoryCache()

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -28,50 +28,42 @@ the PWHOIS query and response format.
 
 ## Choose a lookup
 
-| Need | Build a query with | Execute with | Response type |
+| Need | Preferred method | Result type |
 | --- | --- | --- | --- |
-| IP or IP batch information | `FormatIpQuery` | `LookupIP` | `IpLookupResponse` |
-| Routing paths for an ASN | `FormatRouteViewQuery` | `LookupRouteView` | `BGPLookupResponse` |
-| Registry data for an ASN | `FormatRegistryQuery` | `LookupRegistry` | `RegistryLookupResponse` |
-| Announced netblocks for an ASN | `FormatNetblockQuery` | `LookupNetblock` | `NetblockLookupResponse` |
+| IP or IP batch information | `LookupIPContext` | `[]WhoIs` |
+| Routing paths for an ASN | `LookupRouteViewContext` | `BGPRoutes` |
+| Registry data for an ASN | `LookupRegistryContext` | `RegistryRecord` |
+| Announced netblocks for an ASN | `LookupNetblockContext` | `NetblockRecord` |
 
-Use the query formatter instead of constructing wire text manually. ASN
-formatters accept decimal input with an optional `AS` prefix. The default IP
+Pass domain inputs to the high-level method instead of constructing wire text.
+ASN lookups accept decimal input with an optional `AS` prefix. The default IP
 batch limit is 500 addresses. Responses are limited to 8 MiB by default.
 
 ## Connection and error handling
 
-The application owns the TCP connection. Create a `WhoisServer`, set defaults,
-connect, use one connection for one lookup, and close the connection when the
-lookup is complete. Every lookup returns its result through a channel, so use a
-buffered channel and always check `response.Error`.
+Each high-level call owns its TCP connection from dial through close and returns
+its result synchronously. The zero-value `WhoisServer` applies the documented
+defaults.
 
 ```go
-server := new(pwhois.WhoisServer)
-server.SetDefaultValues()
-if err := server.Connect(); err != nil {
-	return err
-}
-defer server.Connection.Close()
-
-query, err := server.FormatIpQuery([]string{"192.0.2.1"})
+server := pwhois.WhoisServer{}
+records, err := server.LookupIPContext(ctx, []string{"192.0.2.1"})
 if err != nil {
 	return err
-}
-
-responses := make(chan pwhois.IpLookupResponse, 1)
-server.LookupIP(query, responses)
-response := <-responses
-if response.Error != nil {
-	return response.Error
 }
 ```
 
 `WhoisServer.Timeout` bounds connection establishment and the full request and
 response exchange; its zero value uses the five-second default. Set it to an
-application-appropriate `time.Duration` before calling `Connect` when a
-different bound is required. The current module has no context-aware high-level
-lookup API; that is tracked in issue #33.
+application-appropriate `time.Duration` before starting a lookup when a
+different bound is required. A shorter context deadline takes precedence.
+Cancellation interrupts an in-progress dial, write, or read.
+
+A configured `WhoisServer` is safe for concurrent high-level calls when the
+application does not mutate its fields during use. Each call has an independent
+connection. A custom `DialContext` hook must itself be concurrency-safe and
+must honor its context. This hook is intended for deterministic tests and
+controlled transport integration.
 
 `WhoisServer.MaxResponseBytes` bounds response data before parsing. Its zero
 value uses `DefaultMaxResponseBytes` (8 MiB), which provides more than 16 KiB
@@ -90,18 +82,21 @@ Do not compare error strings or expose full server response content in calling
 application logs.
 
 Handle connection, write, read, rate-limit, and parser errors as normal
-application outcomes. Do not silently retry rate-limit errors, share one
-connection among unrelated lookups, or treat a partial result as successful.
+application outcomes. Do not silently retry rate-limit errors or treat a
+partial result as successful.
+
+The exported query formatters, `Connect`, `Connection`, channel lookup methods,
+and channel response wrappers remain for compatibility with existing
+integrations. They are deprecated for new code. If maintaining a legacy
+integration, use one connected `WhoisServer` for one lookup and close its
+`Connection`.
 
 ## Optional cache orchestration
 
-`CacheCoordinator` is a building block for an application's future
-context-aware lookup layer. It does not automatically wrap `LookupIP`,
-`LookupRouteView`, `LookupRegistry`, or `LookupNetblock`, and it does not change
-their caller-owned connection lifecycle. Do not introduce a goroutine around a
-legacy lookup merely to make it fit the coordinator; use the high-level API
-tracked in issue #33 when it becomes available, or supply an application-owned
-context-aware fetch operation.
+`CacheCoordinator` does not automatically wrap `LookupIPContext`,
+`LookupRouteViewContext`, `LookupRegistryContext`, or
+`LookupNetblockContext`. Supply a high-level lookup as the application's
+context-aware fetch operation and retain explicit source policy.
 
 If the application uses this cache contract, read the
 [cache contract guide](cache-contract.md). In particular, configure a policy
@@ -124,7 +119,7 @@ synthetic/reserved documentation values such as `192.0.2.1` in examples.
 1. Confirm that native PWHOIS is the required protocol and select one lookup.
 2. Inspect the chosen module version and its formatter and response type.
 3. Set application-appropriate timeout, response-size, and rate-limit policy.
-4. Close the connection, classify every returned error with `errors.Is`, and
-   test malformed or unavailable-server behavior in the application.
+4. Classify every returned error with `errors.Is`, and test cancellation,
+   malformed responses, and unavailable-server behavior in the application.
 5. Keep orchestration, retries, logging, credentials, storage, and any action
    taken from results in application code.

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -61,8 +61,8 @@ Cancellation interrupts an in-progress dial, write, or read.
 
 A configured `WhoisServer` is safe for concurrent high-level calls when the
 application does not mutate its fields during use. Each call has an independent
-connection. A custom `DialContext` hook must itself be concurrency-safe and
-must honor its context. This hook is intended for deterministic tests and
+connection. A custom `ContextDialer` must itself be concurrency-safe and must
+honor its context. This hook is intended for deterministic tests and
 controlled transport integration.
 
 `WhoisServer.MaxResponseBytes` bounds response data before parsing. Its zero

--- a/pwhois.go
+++ b/pwhois.go
@@ -211,10 +211,12 @@ func parseResponseFloat64(field, value string) (float64, error) {
 	return parsed, nil
 }
 
-// DialContextFunc establishes a network connection for a high-level lookup.
-// The default uses net.Dialer. Tests and applications with custom transports
+// ContextDialer establishes a network connection for a high-level lookup.
+// The default is a net.Dialer. Tests and applications with custom transports
 // may supply a replacement that honors context cancellation.
-type DialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+type ContextDialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
 
 // Whois server object
 type WhoisServer struct {
@@ -227,10 +229,10 @@ type WhoisServer struct {
 	// MaxResponseBytes bounds response data read before parsing. A value less
 	// than or equal to zero uses DefaultMaxResponseBytes.
 	MaxResponseBytes int64
-	// DialContext optionally replaces the default TCP dialer used by the
+	// Dialer optionally replaces the default TCP dialer used by the
 	// context-aware high-level lookup methods. A replacement must be safe for
 	// concurrent use when the WhoisServer is shared by concurrent callers.
-	DialContext DialContextFunc
+	Dialer ContextDialer
 	// Connection is used only by the deprecated low-level Connect and channel
 	// lookup API. High-level context-aware lookups ignore this field and own a
 	// separate connection per call.

--- a/pwhois.go
+++ b/pwhois.go
@@ -211,6 +211,11 @@ func parseResponseFloat64(field, value string) (float64, error) {
 	return parsed, nil
 }
 
+// DialContextFunc establishes a network connection for a high-level lookup.
+// The default uses net.Dialer. Tests and applications with custom transports
+// may supply a replacement that honors context cancellation.
+type DialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
 // Whois server object
 type WhoisServer struct {
 	Server       string `default:"whois.pwhois.org"`
@@ -222,7 +227,14 @@ type WhoisServer struct {
 	// MaxResponseBytes bounds response data read before parsing. A value less
 	// than or equal to zero uses DefaultMaxResponseBytes.
 	MaxResponseBytes int64
-	Connection       net.Conn
+	// DialContext optionally replaces the default TCP dialer used by the
+	// context-aware high-level lookup methods. A replacement must be safe for
+	// concurrent use when the WhoisServer is shared by concurrent callers.
+	DialContext DialContextFunc
+	// Connection is used only by the deprecated low-level Connect and channel
+	// lookup API. High-level context-aware lookups ignore this field and own a
+	// separate connection per call.
+	Connection net.Conn
 }
 
 // Return full DNS server socket Aadress
@@ -275,14 +287,6 @@ func (server WhoisServer) timeout() time.Duration {
 	return time.Second * time.Duration(SocketTimeout)
 }
 
-// setLookupDeadline bounds both the request write and response read. PWHOIS
-// lookups use a connection per request, so the deadline covers the complete
-// exchange rather than allowing a server that stops responding to block
-// indefinitely.
-func (server WhoisServer) setLookupDeadline() error {
-	return server.Connection.SetDeadline(time.Now().Add(server.timeout()))
-}
-
 func (server WhoisServer) operationError(operation string, err error) error {
 	endpoint := ""
 	if server.Server != "" && server.Port != 0 {
@@ -307,6 +311,18 @@ func classifyTransportError(err error) error {
 	return fmt.Errorf("%w: %w", ErrConnection, err)
 }
 
+func classifyContextTransportError(ctx context.Context, err error) error {
+	if ctx != nil {
+		if contextError := ctx.Err(); contextError != nil {
+			return classifyTransportError(contextError)
+		}
+		if deadline, ok := ctx.Deadline(); ok && !time.Now().Before(deadline) {
+			return classifyTransportError(context.DeadlineExceeded)
+		}
+	}
+	return classifyTransportError(err)
+}
+
 func isRateLimitedResponse(response string) bool {
 	return strings.Contains(strings.ToLower(response), "query limit exceeded")
 }
@@ -314,14 +330,18 @@ func isRateLimitedResponse(response string) bool {
 // executeQuery applies one consistent connection, deadline, transport, and
 // rate-limit error contract to every native PWHOIS lookup.
 func (server WhoisServer) executeQuery(operation, query string) (string, error) {
+	return server.executeQueryContext(nil, operation, query, time.Now().Add(server.timeout()))
+}
+
+func (server WhoisServer) executeQueryContext(ctx context.Context, operation, query string, deadline time.Time) (string, error) {
 	if server.Connection == nil {
 		return "", server.operationError(operation, ErrConnection)
 	}
-	if err := server.setLookupDeadline(); err != nil {
-		return "", server.operationError(operation, classifyTransportError(err))
+	if err := server.Connection.SetDeadline(deadline); err != nil {
+		return "", server.operationError(operation, classifyContextTransportError(ctx, err))
 	}
 	if _, err := server.Connection.Write([]byte(query)); err != nil {
-		return "", server.operationError(operation, classifyTransportError(err))
+		return "", server.operationError(operation, classifyContextTransportError(ctx, err))
 	}
 
 	response, err := server.readLookupResponse()
@@ -329,7 +349,10 @@ func (server WhoisServer) executeQuery(operation, query string) (string, error) 
 		if errors.Is(err, ErrResponseTooLarge) {
 			return "", server.operationError(operation, err)
 		}
-		return "", server.operationError(operation, classifyTransportError(err))
+		return "", server.operationError(operation, classifyContextTransportError(ctx, err))
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return "", server.operationError(operation, classifyTransportError(ctx.Err()))
 	}
 	if isRateLimitedResponse(response) {
 		return "", server.operationError(operation, ErrRateLimited)
@@ -407,6 +430,10 @@ func readBoundedResponse(reader io.Reader, limit int64) ([]byte, error) {
 }
 
 // Establish connection to the pwhois server
+//
+// Deprecated: use LookupIPContext, LookupRouteViewContext,
+// LookupRegistryContext, or LookupNetblockContext. Those methods own and close
+// a connection for each call.
 func (server *WhoisServer) Connect() error {
 
 	whoisDialer := &net.Dialer{

--- a/pwhois_context.go
+++ b/pwhois_context.go
@@ -1,0 +1,180 @@
+package pwhois
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+func (server WhoisServer) configured() WhoisServer {
+	server.SetDefaultValues()
+	return server
+}
+
+func (server WhoisServer) dial(ctx context.Context) (net.Conn, error) {
+	if server.DialContext != nil {
+		return server.DialContext(ctx, "tcp", server.ServerAddressString())
+	}
+
+	dialer := &net.Dialer{
+		KeepAlive: time.Second * time.Duration(SocketKeepAlive),
+	}
+	return dialer.DialContext(ctx, "tcp", server.ServerAddressString())
+}
+
+// executeOwnedQuery performs a complete high-level lookup transport exchange.
+// It applies the shorter of the caller's deadline and WhoisServer.Timeout,
+// closes the connection on cancellation, and always closes the connection
+// before returning.
+func (server WhoisServer) executeOwnedQuery(ctx context.Context, operation, query string) (string, error) {
+	if ctx == nil {
+		return "", server.operationError(operation, invalidInputError("context must not be nil"))
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, server.timeout())
+	defer cancel()
+
+	connection, err := server.dial(lookupCtx)
+	if err != nil {
+		return "", server.operationError(operation, classifyContextTransportError(lookupCtx, err))
+	}
+	if connection == nil {
+		return "", server.operationError(operation, ErrConnection)
+	}
+	defer connection.Close()
+
+	stopCancellationClose := context.AfterFunc(lookupCtx, func() {
+		_ = connection.Close()
+	})
+	defer stopCancellationClose()
+
+	deadline, _ := lookupCtx.Deadline()
+
+	server.Connection = connection
+	return server.executeQueryContext(lookupCtx, operation, query, deadline)
+}
+
+// LookupIPContext looks up one or more IP addresses using a connection owned
+// by this call. The zero-value WhoisServer uses the documented defaults.
+//
+// The method honors context cancellation and the shorter of the context
+// deadline and WhoisServer.Timeout. It is safe to call concurrently on the
+// same WhoisServer when its configuration and any custom DialContext function
+// are not mutated during the calls.
+func (server WhoisServer) LookupIPContext(ctx context.Context, values []string) ([]WhoIs, error) {
+	server = server.configured()
+	query, err := server.FormatIpQuery(values)
+	if err != nil {
+		return nil, server.operationError("lookup IP", err)
+	}
+
+	response, err := server.executeOwnedQuery(ctx, "lookup IP", query)
+	if err != nil {
+		return nil, err
+	}
+
+	records, err := parseIpResponse(response)
+	if err != nil {
+		return nil, server.operationError("lookup IP", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, server.operationError("lookup IP", classifyTransportError(err))
+	}
+	return records, nil
+}
+
+// LookupRouteViewContext looks up observed routes for an ASN using a
+// connection owned by this call. ASN accepts decimal digits with an optional
+// case-insensitive AS prefix.
+//
+// It has the same context, deadline, and concurrency guarantees as
+// LookupIPContext.
+func (server WhoisServer) LookupRouteViewContext(ctx context.Context, asn string) (BGPRoutes, error) {
+	server = server.configured()
+	normalizedASN, err := normalizeASN(asn)
+	if err != nil {
+		return BGPRoutes{}, server.operationError("lookup RouteView", err)
+	}
+	query, err := server.FormatRouteViewQuery(normalizedASN)
+	if err != nil {
+		return BGPRoutes{}, server.operationError("lookup RouteView", err)
+	}
+
+	response, err := server.executeOwnedQuery(ctx, "lookup RouteView", query)
+	if err != nil {
+		return BGPRoutes{}, err
+	}
+
+	routes, err := parseBgpResponse(response)
+	if err != nil {
+		return BGPRoutes{}, server.operationError("lookup RouteView", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return BGPRoutes{}, server.operationError("lookup RouteView", classifyTransportError(err))
+	}
+	return BGPRoutes{Asn: normalizedASN, Routes: routes}, nil
+}
+
+// LookupRegistryContext looks up registry data for an ASN using a connection
+// owned by this call. ASN accepts decimal digits with an optional
+// case-insensitive AS prefix.
+//
+// It has the same context, deadline, and concurrency guarantees as
+// LookupIPContext.
+func (server WhoisServer) LookupRegistryContext(ctx context.Context, asn string) (RegistryRecord, error) {
+	server = server.configured()
+	normalizedASN, err := normalizeASN(asn)
+	if err != nil {
+		return RegistryRecord{}, server.operationError("lookup registry", err)
+	}
+	query, err := server.FormatRegistryQuery(normalizedASN)
+	if err != nil {
+		return RegistryRecord{}, server.operationError("lookup registry", err)
+	}
+
+	response, err := server.executeOwnedQuery(ctx, "lookup registry", query)
+	if err != nil {
+		return RegistryRecord{}, err
+	}
+
+	records, err := parseRegistryResponse(response)
+	if err != nil {
+		return RegistryRecord{}, server.operationError("lookup registry", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return RegistryRecord{}, server.operationError("lookup registry", classifyTransportError(err))
+	}
+	return RegistryRecord{Asn: normalizedASN, Registry: records[0]}, nil
+}
+
+// LookupNetblockContext looks up announced netblocks for an ASN using a
+// connection owned by this call. ASN accepts decimal digits with an optional
+// case-insensitive AS prefix.
+//
+// It has the same context, deadline, and concurrency guarantees as
+// LookupIPContext.
+func (server WhoisServer) LookupNetblockContext(ctx context.Context, asn string) (NetblockRecord, error) {
+	server = server.configured()
+	normalizedASN, err := normalizeASN(asn)
+	if err != nil {
+		return NetblockRecord{}, server.operationError("lookup netblock", err)
+	}
+	query, err := server.FormatNetblockQuery(normalizedASN)
+	if err != nil {
+		return NetblockRecord{}, server.operationError("lookup netblock", err)
+	}
+
+	response, err := server.executeOwnedQuery(ctx, "lookup netblock", query)
+	if err != nil {
+		return NetblockRecord{}, err
+	}
+
+	records, err := parseNetblockResponse(normalizedASN, response)
+	if err != nil {
+		return NetblockRecord{}, server.operationError("lookup netblock", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return NetblockRecord{}, server.operationError("lookup netblock", classifyTransportError(err))
+	}
+	return records[0], nil
+}

--- a/pwhois_context.go
+++ b/pwhois_context.go
@@ -12,8 +12,8 @@ func (server WhoisServer) configured() WhoisServer {
 }
 
 func (server WhoisServer) dial(ctx context.Context) (net.Conn, error) {
-	if server.DialContext != nil {
-		return server.DialContext(ctx, "tcp", server.ServerAddressString())
+	if server.Dialer != nil {
+		return server.Dialer.DialContext(ctx, "tcp", server.ServerAddressString())
 	}
 
 	dialer := &net.Dialer{
@@ -59,8 +59,8 @@ func (server WhoisServer) executeOwnedQuery(ctx context.Context, operation, quer
 //
 // The method honors context cancellation and the shorter of the context
 // deadline and WhoisServer.Timeout. It is safe to call concurrently on the
-// same WhoisServer when its configuration and any custom DialContext function
-// are not mutated during the calls.
+// same WhoisServer when its configuration and any custom Dialer are not
+// mutated during the calls.
 func (server WhoisServer) LookupIPContext(ctx context.Context, values []string) ([]WhoIs, error) {
 	server = server.configured()
 	query, err := server.FormatIpQuery(values)

--- a/pwhois_context_test.go
+++ b/pwhois_context_test.go
@@ -1,0 +1,292 @@
+package pwhois
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const (
+	contextIPRequest       = "app=\"GO pwhois Module\"\n192.0.2.1\n"
+	contextRouteRequest    = "app=\"GO pwhois Module\" routeview source-as=64500\n"
+	contextRegistryRequest = "app=\"GO pwhois Module\" registry source-as=64500\n"
+	contextNetblockRequest = "app=\"GO pwhois Module\" netblock source-as=64500\n"
+
+	contextIPResponse    = "IP: 192.0.2.1\nOrigin-AS: 64500\nOrg-Name: Example Network\nCountry-Code: ZZ"
+	contextRouteResponse = "Origin-AS: 64500\n" +
+		"*> 192.0.2.0/24 | Jul 18 2026 00:00:04 | Jul 18 2026 00:00:04 | May 28 2026 06:56:01 | 192.0.2.254 | 64501 64500"
+	contextRegistryResponse = "Org-Record: TEST-ORG\nOrg-ID: TEST\nOrg-Name: Example Registry Organization\n" +
+		"Can-Allocate: 1\nSource: TEST\nPostal-Code: 00000\nCountry-Code: ZZ"
+	contextNetblockResponse = "Origin-AS: 64500\nAS: 64500\nAS-Source: TEST\nOrg: 1\nOrg-ID: TEST\nOrg-Name: Example Networks\nOrg-Source: TEST\n" +
+		"*> 192.0.2.0 - 192.0.2.255 | EXAMPLE-NET | reassignment | 2019-05-25 | 2019-09-25 | Jun 28 2019 16:53:01 | Jul 18 2026 03:19:32 | TEST"
+)
+
+func TestContextLookupsOwnCompleteConnectionLifecycle(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  string
+		response string
+		lookup   func(context.Context, WhoisServer) error
+	}{
+		{
+			name:     "IP",
+			request:  contextIPRequest,
+			response: contextIPResponse,
+			lookup: func(ctx context.Context, server WhoisServer) error {
+				records, err := server.LookupIPContext(ctx, []string{"192.0.2.1"})
+				if err == nil && (len(records) != 1 || records[0].OriginAS != "64500") {
+					return fmt.Errorf("unexpected IP records: %+v", records)
+				}
+				return err
+			},
+		},
+		{
+			name:     "RouteView",
+			request:  contextRouteRequest,
+			response: contextRouteResponse,
+			lookup: func(ctx context.Context, server WhoisServer) error {
+				routes, err := server.LookupRouteViewContext(ctx, "AS64500")
+				if err == nil && (routes.Asn != "64500" || len(routes.Routes) != 1) {
+					return fmt.Errorf("unexpected RouteView response: %+v", routes)
+				}
+				return err
+			},
+		},
+		{
+			name:     "registry",
+			request:  contextRegistryRequest,
+			response: contextRegistryResponse,
+			lookup: func(ctx context.Context, server WhoisServer) error {
+				record, err := server.LookupRegistryContext(ctx, "as64500")
+				if err == nil && (record.Asn != "64500" || record.Registry.OrgID != "TEST") {
+					return fmt.Errorf("unexpected registry response: %+v", record)
+				}
+				return err
+			},
+		},
+		{
+			name:     "netblock",
+			request:  contextNetblockRequest,
+			response: contextNetblockResponse,
+			lookup: func(ctx context.Context, server WhoisServer) error {
+				record, err := server.LookupNetblockContext(ctx, "64500")
+				if err == nil && (record.Asn != "64500" || len(record.Netblocks) != 1) {
+					return fmt.Errorf("unexpected netblock response: %+v", record)
+				}
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, results := startLoopbackProtocolServer(t, loopbackProtocolScript{
+				expectedRequest: test.request,
+				responseChunks:  []string{test.response},
+			})
+
+			if err := test.lookup(context.Background(), *server); err != nil {
+				t.Fatalf("context lookup: %v", err)
+			}
+			if server.Connection != nil {
+				t.Error("context lookup mutated the caller's Connection field")
+			}
+			verifyAutomaticallyClosedLoopbackProtocol(t, results, test.request)
+		})
+	}
+}
+
+func TestContextLookupZeroValueUsesDefaultsAndDialHook(t *testing.T) {
+	var (
+		gotNetwork string
+		gotAddress string
+	)
+	serverDone := make(chan error, 1)
+	server := WhoisServer{
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			gotNetwork = network
+			gotAddress = address
+			client, provider := net.Pipe()
+			go func() {
+				defer provider.Close()
+				request := make([]byte, len(contextIPRequest))
+				if _, err := io.ReadFull(provider, request); err != nil {
+					serverDone <- err
+					return
+				}
+				if string(request) != contextIPRequest {
+					serverDone <- fmt.Errorf("request = %q", request)
+					return
+				}
+				_, err := io.WriteString(provider, contextIPResponse)
+				serverDone <- err
+			}()
+			return client, nil
+		},
+	}
+
+	records, err := server.LookupIPContext(context.Background(), []string{"192.0.2.1"})
+	if err != nil {
+		t.Fatalf("LookupIPContext: %v", err)
+	}
+	if len(records) != 1 || records[0].IP != "192.0.2.1" {
+		t.Fatalf("records = %+v", records)
+	}
+	if gotNetwork != "tcp" || gotAddress != "whois.pwhois.org:43" {
+		t.Errorf("dial = %s %s, want tcp whois.pwhois.org:43", gotNetwork, gotAddress)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatalf("injected provider: %v", err)
+	}
+}
+
+func TestContextLookupCancellationClosesConnection(t *testing.T) {
+	server, results := startLoopbackProtocolServer(t, loopbackProtocolScript{
+		expectedRequest: contextIPRequest,
+		noResponse:      true,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(50*time.Millisecond, cancel)
+	defer cancel()
+
+	_, err := server.LookupIPContext(ctx, []string{"192.0.2.1"})
+	if !errors.Is(err, ErrCanceled) || !errors.Is(err, context.Canceled) {
+		t.Fatalf("lookup error = %v, want ErrCanceled and context.Canceled", err)
+	}
+	verifyAutomaticallyClosedLoopbackProtocol(t, results, contextIPRequest)
+}
+
+func TestContextLookupTimeoutClosesConnection(t *testing.T) {
+	server, results := startLoopbackProtocolServer(t, loopbackProtocolScript{
+		expectedRequest: contextIPRequest,
+		noResponse:      true,
+	})
+	server.Timeout = 50 * time.Millisecond
+
+	_, err := server.LookupIPContext(context.Background(), []string{"192.0.2.1"})
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("lookup error = %v, want ErrTimeout", err)
+	}
+	verifyAutomaticallyClosedLoopbackProtocol(t, results, contextIPRequest)
+}
+
+func TestContextLookupCallerDeadlineTakesPrecedence(t *testing.T) {
+	server, results := startLoopbackProtocolServer(t, loopbackProtocolScript{
+		expectedRequest: contextIPRequest,
+		noResponse:      true,
+	})
+	server.Timeout = 2 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := server.LookupIPContext(ctx, []string{"192.0.2.1"})
+	if !errors.Is(err, ErrTimeout) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("lookup error = %v, want ErrTimeout and context.DeadlineExceeded", err)
+	}
+	verifyAutomaticallyClosedLoopbackProtocol(t, results, contextIPRequest)
+}
+
+func TestContextLookupCancellationReachesDialer(t *testing.T) {
+	dialStarted := make(chan struct{})
+	server := WhoisServer{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			close(dialStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-dialStarted
+		cancel()
+	}()
+
+	_, err := server.LookupIPContext(ctx, []string{"192.0.2.1"})
+	if !errors.Is(err, ErrCanceled) || !errors.Is(err, context.Canceled) {
+		t.Fatalf("dial error = %v, want ErrCanceled and context.Canceled", err)
+	}
+}
+
+func TestContextLookupTimeoutReachesDialer(t *testing.T) {
+	server := WhoisServer{
+		Timeout: 50 * time.Millisecond,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	_, err := server.LookupIPContext(context.Background(), []string{"192.0.2.1"})
+	if !errors.Is(err, ErrTimeout) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("dial error = %v, want ErrTimeout and context.DeadlineExceeded", err)
+	}
+}
+
+func TestContextLookupRejectsNilContext(t *testing.T) {
+	_, err := (WhoisServer{}).LookupIPContext(nil, []string{"192.0.2.1"})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("lookup error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestContextLookupsAreSafeForConcurrentUse(t *testing.T) {
+	var dialCount atomic.Int64
+	serverErrors := make(chan error, 32)
+	server := WhoisServer{
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			dialCount.Add(1)
+			client, provider := net.Pipe()
+			go func() {
+				defer provider.Close()
+				request := make([]byte, len(contextIPRequest))
+				if _, err := io.ReadFull(provider, request); err != nil {
+					serverErrors <- err
+					return
+				}
+				if string(request) != contextIPRequest {
+					serverErrors <- fmt.Errorf("request = %q", request)
+					return
+				}
+				_, err := io.WriteString(provider, contextIPResponse)
+				serverErrors <- err
+			}()
+			return client, nil
+		},
+	}
+
+	var wait sync.WaitGroup
+	lookupErrors := make(chan error, 32)
+	for i := 0; i < 32; i++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			records, err := server.LookupIPContext(context.Background(), []string{"192.0.2.1"})
+			if err == nil && (len(records) != 1 || records[0].IP != "192.0.2.1") {
+				err = fmt.Errorf("unexpected records: %+v", records)
+			}
+			lookupErrors <- err
+		}()
+	}
+	wait.Wait()
+
+	for i := 0; i < 32; i++ {
+		if err := <-lookupErrors; err != nil {
+			t.Errorf("concurrent lookup: %v", err)
+		}
+		if err := <-serverErrors; err != nil {
+			t.Errorf("concurrent provider: %v", err)
+		}
+	}
+	if got := dialCount.Load(); got != 32 {
+		t.Errorf("dial count = %d, want 32 independent connections", got)
+	}
+	if server.Connection != nil {
+		t.Error("concurrent context lookups mutated shared Connection")
+	}
+}

--- a/pwhois_context_test.go
+++ b/pwhois_context_test.go
@@ -12,6 +12,12 @@ import (
 	"time"
 )
 
+type contextDialerFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+func (dial contextDialerFunc) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return dial(ctx, network, address)
+}
+
 const (
 	contextIPRequest       = "app=\"GO pwhois Module\"\n192.0.2.1\n"
 	contextRouteRequest    = "app=\"GO pwhois Module\" routeview source-as=64500\n"
@@ -109,7 +115,7 @@ func TestContextLookupZeroValueUsesDefaultsAndDialHook(t *testing.T) {
 	)
 	serverDone := make(chan error, 1)
 	server := WhoisServer{
-		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+		Dialer: contextDialerFunc(func(ctx context.Context, network, address string) (net.Conn, error) {
 			gotNetwork = network
 			gotAddress = address
 			client, provider := net.Pipe()
@@ -128,7 +134,7 @@ func TestContextLookupZeroValueUsesDefaultsAndDialHook(t *testing.T) {
 				serverDone <- err
 			}()
 			return client, nil
-		},
+		}),
 	}
 
 	records, err := server.LookupIPContext(context.Background(), []string{"192.0.2.1"})
@@ -195,11 +201,11 @@ func TestContextLookupCallerDeadlineTakesPrecedence(t *testing.T) {
 func TestContextLookupCancellationReachesDialer(t *testing.T) {
 	dialStarted := make(chan struct{})
 	server := WhoisServer{
-		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+		Dialer: contextDialerFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
 			close(dialStarted)
 			<-ctx.Done()
 			return nil, ctx.Err()
-		},
+		}),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -216,10 +222,10 @@ func TestContextLookupCancellationReachesDialer(t *testing.T) {
 func TestContextLookupTimeoutReachesDialer(t *testing.T) {
 	server := WhoisServer{
 		Timeout: 50 * time.Millisecond,
-		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+		Dialer: contextDialerFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
 			<-ctx.Done()
 			return nil, ctx.Err()
-		},
+		}),
 	}
 
 	_, err := server.LookupIPContext(context.Background(), []string{"192.0.2.1"})
@@ -239,7 +245,7 @@ func TestContextLookupsAreSafeForConcurrentUse(t *testing.T) {
 	var dialCount atomic.Int64
 	serverErrors := make(chan error, 32)
 	server := WhoisServer{
-		DialContext: func(context.Context, string, string) (net.Conn, error) {
+		Dialer: contextDialerFunc(func(context.Context, string, string) (net.Conn, error) {
 			dialCount.Add(1)
 			client, provider := net.Pipe()
 			go func() {
@@ -257,7 +263,7 @@ func TestContextLookupsAreSafeForConcurrentUse(t *testing.T) {
 				serverErrors <- err
 			}()
 			return client, nil
-		},
+		}),
 	}
 
 	var wait sync.WaitGroup
@@ -288,5 +294,14 @@ func TestContextLookupsAreSafeForConcurrentUse(t *testing.T) {
 	}
 	if server.Connection != nil {
 		t.Error("concurrent context lookups mutated shared Connection")
+	}
+}
+
+func TestWhoisServerRemainsComparable(t *testing.T) {
+	servers := map[WhoisServer]string{
+		{}: "zero value",
+	}
+	if got := servers[WhoisServer{}]; got != "zero value" {
+		t.Fatalf("map lookup = %q, want zero value", got)
 	}
 }

--- a/pwhois_ip.go
+++ b/pwhois_ip.go
@@ -165,6 +165,8 @@ args:
 
 >c: a channel to return an IpLookupResponse struct
 */
+// Deprecated: use LookupIPContext, which formats the query and owns the
+// connection lifecycle.
 func (server WhoisServer) LookupIP(query string, c chan IpLookupResponse) {
 
 	var Answer []WhoIs

--- a/pwhois_netblock.go
+++ b/pwhois_netblock.go
@@ -214,6 +214,8 @@ args:
 
 >c: a channel to return an BGPLookupResponse struct
 */
+// Deprecated: use LookupNetblockContext, which formats the query and owns the
+// connection lifecycle.
 func (server WhoisServer) LookupNetblock(asn string, query string, c chan NetblockLookupResponse) {
 
 	var Answer NetblockRecord

--- a/pwhois_protocol_test.go
+++ b/pwhois_protocol_test.go
@@ -22,12 +22,12 @@ type loopbackProtocolResult struct {
 	err          error
 }
 
-// connectLoopbackProtocolServer starts a one-connection, IPv4 loopback-only
-// PWHOIS test server and connects through WhoisServer.Connect. The server
+// startLoopbackProtocolServer starts a one-connection, IPv4 loopback-only
+// PWHOIS test server. The server
 // reads the exact scripted request, optionally returns response chunks, sends
 // orderly EOF with CloseWrite, and then verifies that the caller closes its
 // side of the connection.
-func connectLoopbackProtocolServer(t *testing.T, script loopbackProtocolScript) (*WhoisServer, <-chan loopbackProtocolResult) {
+func startLoopbackProtocolServer(t *testing.T, script loopbackProtocolScript) (*WhoisServer, <-chan loopbackProtocolResult) {
 	t.Helper()
 
 	listener, err := net.Listen("tcp4", "127.0.0.1:0")
@@ -101,17 +101,24 @@ func connectLoopbackProtocolServer(t *testing.T, script loopbackProtocolScript) 
 		Timeout:          2 * time.Second,
 		MaxResponseBytes: DefaultMaxResponseBytes,
 	}
-	if err := server.Connect(); err != nil {
-		listener.Close()
-		t.Fatalf("connect to loopback server: %v", err)
-	}
-
 	t.Cleanup(func() {
 		if server.Connection != nil {
 			_ = server.Connection.Close()
 		}
 		_ = listener.Close()
 	})
+	return server, results
+}
+
+// connectLoopbackProtocolServer starts a scripted server and connects through
+// the deprecated low-level connection API.
+func connectLoopbackProtocolServer(t *testing.T, script loopbackProtocolScript) (*WhoisServer, <-chan loopbackProtocolResult) {
+	t.Helper()
+
+	server, results := startLoopbackProtocolServer(t, script)
+	if err := server.Connect(); err != nil {
+		t.Fatalf("connect to loopback server: %v", err)
+	}
 	return server, results
 }
 
@@ -131,6 +138,25 @@ func closeAndVerifyLoopbackProtocol(t *testing.T, server *WhoisServer, results <
 		}
 		if !result.clientClosed {
 			t.Error("loopback server did not observe client connection cleanup")
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("loopback protocol server did not finish")
+	}
+}
+
+func verifyAutomaticallyClosedLoopbackProtocol(t *testing.T, results <-chan loopbackProtocolResult, expectedRequest string) {
+	t.Helper()
+
+	select {
+	case result := <-results:
+		if result.err != nil {
+			t.Fatalf("loopback protocol server: %v", result.err)
+		}
+		if result.request != expectedRequest {
+			t.Errorf("wire request = %q, want %q", result.request, expectedRequest)
+		}
+		if !result.clientClosed {
+			t.Error("loopback server did not observe automatic client connection cleanup")
 		}
 	case <-time.After(4 * time.Second):
 		t.Fatal("loopback protocol server did not finish")

--- a/pwhois_registry.go
+++ b/pwhois_registry.go
@@ -174,6 +174,8 @@ args:
 
 >c: a channel to return an BGPLookupResponse struct
 */
+// Deprecated: use LookupRegistryContext, which formats the query and owns the
+// connection lifecycle.
 func (server WhoisServer) LookupRegistry(asn string, query string, c chan RegistryLookupResponse) {
 
 	var Answer RegistryRecord

--- a/pwhois_routeview.go
+++ b/pwhois_routeview.go
@@ -140,6 +140,8 @@ args:
 
 >c: a channel to return an BGPLookupResponse struct
 */
+// Deprecated: use LookupRouteViewContext, which formats the query and owns the
+// connection lifecycle.
 func (server WhoisServer) LookupRouteView(asn string, query string, c chan BGPLookupResponse) {
 
 	var Answer BGPRoutes


### PR DESCRIPTION
## Summary

- add synchronous context-aware IP, RouteView, registry, and netblock lookup methods that accept domain inputs
- make each high-level call own its dial, write, read, parse, and connection cleanup lifecycle
- add a context-aware dialing hook for deterministic tests and controlled transports
- document zero-value defaults, cancellation/deadline behavior, concurrency guarantees, and the legacy compatibility path
- retain the existing low-level channel API while deprecating it for new integrations

## Compatibility

This is an additive API change. Existing exported formatters, `Connect`, `Connection`, channel lookup methods, and response wrappers remain available. The new high-level methods are preferred, while issue #36 remains responsible for the longer-term public API compatibility gate and any future major-version decision.

## Validation

- `go test ./...`
- `go test -run 'TestContext' -count=20 ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

All required tests use loopback or injected transports and do not contact a public PWHOIS server.

Closes #33