### PR TITLE
Add explicit Team Cymru IP-to-ASN provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,19 @@
 # Repository maintainer guide for pwhois
 
-This repository is a Go client and parser for native PWHOIS queries. This file
-is the maintainer contract for automated coding assistants changing this
-repository. It is not consumer integration guidance; assistants adding the
-released module to another application must start with
+This repository is a Go client and parser for native PWHOIS queries plus
+explicit source-specific enrichment providers. This file is the maintainer
+contract for automated coding assistants changing this repository. It is not
+consumer integration guidance; assistants adding the released module to
+another application must start with
 [`docs/consumer-agent-guide.md`](docs/consumer-agent-guide.md).
 
 ## Scope and contracts
 
-- `pwhois` supports PWHOIS IP, RouteView, registry, and netblock queries.
-  It is not a generic WHOIS, IRR, or RDAP client. Changing only
-  `WhoisServer.Server` does not establish compatibility with another server or
-  response format; add format-specific implementation and tests first.
+- `pwhois` supports native PWHOIS IP, RouteView, registry, and netblock queries
+  plus the explicit `TeamCymruProvider` IP-to-ASN protocol. It is not a generic
+  WHOIS, IRR, or RDAP client. Changing only `WhoisServer.Server` or a provider
+  hostname does not establish compatibility with another response format; add
+  a source-specific implementation and tests first.
 - The exported Go API, JSON field names, README, and deterministic tests are
   consumer-facing contracts. Keep them aligned when behavior changes. Preserve
   the serialization conventions corrected in #22 and #25 deliberately; use
@@ -19,7 +21,7 @@ released module to another application must start with
   issue #36 for compatibility work.
 - Treat every server response as untrusted. Handle malformed, truncated,
   delimiter-containing, and oversized values without panics or data loss.
-  All lookups enforce `WhoisServer.MaxResponseBytes`; preserve the shared
+  All lookups enforce their configured `MaxResponseBytes`; preserve the shared
   bounded-reader semantics and the stable error contract.
 - Do not add library stdout output. Return errors through the documented
   response types and keep logging, retries, orchestration, and policy in the
@@ -37,6 +39,9 @@ released module to another application must start with
 - `WhoisServer.Timeout` bounds connection establishment and the full lookup
   write/read exchange. Its zero value uses the five-second default. A shorter
   context deadline takes precedence for high-level calls.
+- `TeamCymruProvider` is always explicit, uses one bulk request for grouped
+  inputs, and never falls back to native PWHOIS. Its country and registry
+  fields are allocation metadata, not geolocation.
 - Respect server rate limits. Rate-limit responses and network errors are
   normal caller-visible outcomes, not conditions to hide with automatic retry.
 
@@ -45,8 +50,9 @@ released module to another application must start with
 - Run `go test ./...`, `go vet ./...`, and `go build ./...` before opening a
   pull request. Use `go test -race ./...` when changing concurrency or network
   behavior.
-- Default tests must be deterministic and must not contact public PWHOIS
-  servers. Live checks are opt-in: `go test -tags=integration ./...`.
+- Default tests must be deterministic and must not contact public PWHOIS, Team
+  Cymru, or other provider servers. Native PWHOIS live checks are opt-in:
+  `go test -tags=integration ./...`.
 - Use reserved and synthetic addresses, ASNs, organizations, and response data
   in tests and documentation. Never commit live/private registry responses,
   contact data, credentials, local paths, or rate-limit artifacts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,8 @@ Thanks for improving `pwhois`.
 ## Scope
 
 `pwhois` is a Go client and parser for native PWHOIS IP, RouteView, registry,
-and netblock queries. It is not a generic WHOIS, IRR, or RDAP client. Keep
+and netblock queries plus explicit source-specific providers such as Team
+Cymru IP-to-ASN mapping. It is not a generic WHOIS, IRR, or RDAP client. Keep
 network policy, retries, logging, storage, scheduling, and application actions
 in the consuming application.
 
@@ -20,7 +21,7 @@ go build ./...
 ```
 
 Also run `go test -race ./...` for concurrency or network changes. Public
-PWHOIS checks are opt-in and must not become required CI:
+provider checks are opt-in and must not become required CI:
 
 ```shell
 go test -tags=integration ./...
@@ -33,9 +34,9 @@ completed review, resolve actionable threads, and ensure CI is green.
 ## Tests and data
 
 Use deterministic loopback tests and synthetic/reserved values. Do not commit
-live PWHOIS responses, organization or contact data, credentials, local paths,
-or rate-limit artifacts. Keep private experiments under ignored paths such as
-`testdata/private/`.
+live provider responses, organization or contact data, credentials, local
+paths, or rate-limit artifacts. Keep private experiments under ignored paths
+such as `testdata/private/`.
 
 ## Public API and release impact
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ and rate-limit policy explicit in the calling application.
 `TeamCymruProvider.CacheKeySpec` returns a source-, endpoint-, protocol-,
 parser-, and schema-aware identity for use with `CacheCoordinator`.
 
+`FetchedAt` records when this client received the response. It is not a claim
+about when the route was first observed by a collector.
+
 Port 43 traffic is plaintext. Do not send an address to this third-party
 provider unless the calling application's privacy and data-handling policy
 allows it.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/georgestarcher/pwhois.svg)](https://pkg.go.dev/github.com/georgestarcher/pwhois)
 [![CI](https://github.com/georgestarcher/pwhois/actions/workflows/go.yml/badge.svg)](https://github.com/georgestarcher/pwhois/actions/workflows/go.yml)
 
-`pwhois` is a Go module for querying a [PWHOIS](https://pwhois.org/) server and parsing its IP, routing, registry, and netblock responses.
+`pwhois` is a Go module for querying a [PWHOIS](https://pwhois.org/)
+server and parsing its IP, routing, registry, and netblock responses. It also
+provides an explicit, source-specific client for
+[Team Cymru IP-to-ASN mapping](https://www.team-cymru.com/ip-asn-mapping).
 
 Created by George Starcher. The implementation references the original [`whob` source code](https://github.com/irr/whob/blob/master/whob).
 
@@ -13,6 +16,7 @@ Created by George Starcher. The implementation references the original [`whob` s
 - RouteView data for an autonomous system number (ASN)
 - Registry data for an ASN
 - Netblocks announced by an ASN
+- Team Cymru IP-to-origin-ASN and prefix enrichment
 
 ## Install
 
@@ -72,7 +76,7 @@ func main() {
 
 The other supported lookup types follow the same pattern. A configured
 `WhoisServer` may be shared by concurrent high-level calls as long as its
-	fields—and any custom `Dialer`—are not mutated while calls are
+fields—and any custom `Dialer`—are not mutated while calls are
 running. Every call uses an independent connection. The older `Connect`,
 `Connection`, query-formatter, channel-response API remains available for
 compatibility but is deprecated for new integrations; callers using it must
@@ -97,7 +101,8 @@ tested with `errors.Is`; error wording is not an API contract.
 | `ErrInvalidInput` | A query formatter rejected caller input. |
 | `ErrConnection` | The connection is absent or a network operation failed. |
 | `ErrTimeout` / `ErrCanceled` | The lookup deadline expired or its connection reported cancellation. |
-| `ErrRateLimited` | The PWHOIS server reported its query limit. |
+| `ErrRateLimited` | A provider reported its query limit. |
+| `ErrProviderRejected` | A provider rejected the query. |
 | `ErrResponseTooLarge` | The response exceeded `MaxResponseBytes`. |
 | `ErrMalformedResponse` | A non-empty response could not be parsed safely. |
 | `ErrNoRecords` | The server returned no records for the lookup. |
@@ -145,13 +150,54 @@ maintainers should use the [maintainer guide](AGENTS.md).
 | Registry | `LookupRegistryContext` | `RegistryRecord` |
 | Netblock | `LookupNetblockContext` | `NetblockRecord` |
 
-## PWHOIS servers
+## Team Cymru IP-to-ASN provider
+
+`TeamCymruProvider` uses Team Cymru's distinct bulk TCP protocol and
+pipe-delimited response format. It is not a replacement hostname for
+`WhoisServer`. The provider validates and deduplicates all inputs, sends one
+bounded bulk request even for a single address, and returns
+`[]TeamCymruIPResult` with explicit source, endpoint, and fetch-time
+provenance.
+
+```go
+provider := pwhois.TeamCymruProvider{
+	BatchMaxSize: 1000,
+}
+results, err := provider.LookupIPContext(context.Background(), []string{
+	"192.0.2.1",
+	"198.51.100.2",
+})
+```
+
+The zero value uses `whois.cymru.com:43`, a five-second timeout, a
+1,000-address batch limit, and the shared 8 MiB response limit. The provider
+never retries, falls back to PWHOIS, or automatically caches results.
+
+Team Cymru describes the returned country code, registry, and allocation date
+as RIR allocation metadata and explicitly warns that the service is not
+geolocation. The service recommends one bulk request for groups of addresses
+and warns against high volumes of individual WHOIS queries. It reports that
+its underlying mapping data is updated at four-hour intervals. Keep cache TTL
+and rate-limit policy explicit in the calling application.
+`TeamCymruProvider.CacheKeySpec` returns a source-, endpoint-, protocol-,
+parser-, and schema-aware identity for use with `CacheCoordinator`.
+
+Port 43 traffic is plaintext. Do not send an address to this third-party
+provider unless the calling application's privacy and data-handling policy
+allows it.
+
+## Providers and servers
 
 `SetDefaultValues` configures `whois.pwhois.org:43`. You can set `WhoisServer.Server` and `WhoisServer.Port` before calling `Connect`, but compatibility with alternative servers is not yet validated. Availability and rate limits are controlled by each server operator.
 
+`TeamCymruProvider` is the only additional protocol-specific provider
+currently implemented. Generic WHOIS, IRR, and RDAP endpoints are not
+drop-in-compatible with either client.
+
 ## Development
 
-The default checks are deterministic and do not contact public PWHOIS servers:
+The default checks are deterministic and do not contact public PWHOIS or Team
+Cymru servers:
 
 ```shell
 go test ./...
@@ -176,9 +222,14 @@ The live tests depend on the public service's availability, response data, and r
 
 ## JSON output
 
-The explicit JSON-tagged data records (`WhoIs`, `BGPRoute`, `BGPRoutes`, `RegistryRecord`, `Registry`, `NetblockRecord`, and `Netblock`) use normalized snake_case keys and are covered by serialization tests. Postal codes are text so leading zeros and alphanumeric values are preserved.
+The explicit JSON-tagged data records (`WhoIs`, `BGPRoute`, `BGPRoutes`,
+`RegistryRecord`, `Registry`, `NetblockRecord`, `Netblock`, and
+`TeamCymruIPResult`) use normalized snake_case keys and are covered by
+serialization tests. Postal codes are text so leading zeros and alphanumeric
+values are preserved.
 
-`WhoisServer` and the channel response wrappers are connection/control types, not JSON output contracts.
+`WhoisServer`, `TeamCymruProvider`, and the channel response wrappers are
+connection/control types, not JSON output contracts.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ Security fixes are applied to the current released `v1` line.
 
 Please report security issues privately through GitHub's private vulnerability
 reporting for this repository. Do not open a public issue, publish a proof of
-concept containing live PWHOIS data, or include credentials, contact data, or
-private network information.
+concept containing live provider data, or include credentials, contact data,
+or private network information.
 
 Include the affected module version, Go version, a synthetic or minimized
 reproduction, impact, and any relevant configuration. We will acknowledge the
@@ -17,7 +17,8 @@ report and coordinate a fix or disclosure as appropriate.
 
 ## Input and network expectations
 
-PWHOIS responses are untrusted network input. The module currently bounds
-connection and lookup I/O time, but applications remain responsible for their
-chosen server, timeout, rate-limit policy, data retention, and how results are
-displayed or acted upon. Response-size limits are tracked in issue #32.
+PWHOIS and source-specific provider responses are untrusted network input. The
+module bounds connection time, lookup I/O time, and response size, but
+applications remain responsible for their chosen provider, privacy policy,
+rate-limit policy, data retention, and how results are displayed or acted
+upon. Port 43 queries are plaintext.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,17 +5,18 @@
 Start with the [README](README.md), [consumer integration guide](docs/consumer-agent-guide.md), and [Go package documentation](https://pkg.go.dev/github.com/georgestarcher/pwhois).
 
 For a question or bug report, include the exact module version, Go version,
-PWHOIS server, lookup type, expected result, actual result, and a minimal
+provider and endpoint, lookup type, expected result, actual result, and a minimal
 synthetic reproduction.
 
 ## Project scope
 
 This project supports native PWHOIS IP, RouteView, registry, and netblock
-queries. Generic WHOIS, IRR, and RDAP protocols are outside its current scope;
-changing only the server hostname does not make them compatible.
+queries plus its documented source-specific providers. Generic WHOIS, IRR,
+and RDAP protocols are outside its current scope; changing only the server
+hostname does not make them compatible.
 
 ## Sensitive data and security
 
-Do not attach live PWHOIS responses, registry contacts, credentials, private
+Do not attach live provider responses, registry contacts, credentials, private
 addresses, or rate-limit artifacts to public issues. For vulnerabilities, use
 the private process in [SECURITY.md](SECURITY.md).

--- a/cache.go
+++ b/cache.go
@@ -185,6 +185,7 @@ const (
 	ProviderErrorTimeout           ProviderErrorClass = "timeout"
 	ProviderErrorCanceled          ProviderErrorClass = "canceled"
 	ProviderErrorRateLimited       ProviderErrorClass = "rate_limited"
+	ProviderErrorRejected          ProviderErrorClass = "provider_rejected"
 	ProviderErrorResponseTooLarge  ProviderErrorClass = "response_too_large"
 	ProviderErrorMalformedResponse ProviderErrorClass = "malformed_response"
 	ProviderErrorNoRecords         ProviderErrorClass = "no_records"
@@ -209,6 +210,8 @@ func ClassifyProviderError(err error) ProviderErrorClass {
 		return ProviderErrorCanceled
 	case errors.Is(err, ErrRateLimited):
 		return ProviderErrorRateLimited
+	case errors.Is(err, ErrProviderRejected):
+		return ProviderErrorRejected
 	case errors.Is(err, ErrResponseTooLarge):
 		return ProviderErrorResponseTooLarge
 	case errors.Is(err, ErrMalformedResponse):
@@ -232,6 +235,8 @@ func providerErrorSentinel(class ProviderErrorClass) error {
 		return ErrCanceled
 	case ProviderErrorRateLimited:
 		return ErrRateLimited
+	case ProviderErrorRejected:
+		return ErrProviderRejected
 	case ProviderErrorResponseTooLarge:
 		return ErrResponseTooLarge
 	case ProviderErrorMalformedResponse:

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,15 +20,17 @@ go vet ./...
 go build ./...
 ```
 
-Live checks use the public default PWHOIS server and are opt-in:
+The available live checks use only the public default native PWHOIS server and
+are opt-in:
 
 ```shell
 go test -tags=integration ./...
 ```
 
-Required protocol coverage uses only a scripted IPv4 loopback server. It
-exercises real TCP connect, request, response, EOF, timeout, and caller cleanup
-behavior without depending on a public service.
+Required native PWHOIS and Team Cymru protocol coverage uses only scripted
+IPv4 loopback servers or injected connections. It exercises real TCP connect,
+request, response, EOF, timeout, cancellation, response bounds, and connection
+cleanup without depending on a public service.
 
 The repository does not yet have a canonical documentation-validation command;
 that work is tracked in issue #28.

--- a/docs/cache-contract.md
+++ b/docs/cache-contract.md
@@ -10,10 +10,10 @@ The cache API separates three responsibilities:
    concurrent fetches for the same canonical key.
 
 This is cache infrastructure, not an implicit wrapper around the high-level
-PWHOIS client. Applications may use `LookupIPContext`,
-`LookupRouteViewContext`, `LookupRegistryContext`, or
-`LookupNetblockContext` inside their context-aware fetch operation, but they
-must still select a source, cache policy, and normalized result explicitly.
+provider clients. Applications may use the native PWHOIS context methods or
+`TeamCymruProvider.LookupIPContext` inside their context-aware fetch operation,
+but they must still select a source, cache policy, and normalized result
+explicitly.
 The deprecated channel-based lookup methods continue to require a caller-owned
 connection.
 
@@ -52,11 +52,11 @@ has no global TTL fallback:
 | `RateLimitedTTL` | Cache lifetime for `ErrRateLimited`; zero disables it. |
 | `MaxStale` | Maximum time after expiry that a successful result may be returned by stale-if-error; zero disables fallback. |
 
-Connection, timeout, cancellation, malformed-response, oversized-response,
-invalid-input, and unknown errors are not cached. Stale-if-error may use a
-successful stale result for a provider timeout, but does not hide cancellation
-or deadline expiry of the caller's context. It never falls back to a stale
-negative or rate-limit entry.
+Connection, timeout, cancellation, provider-rejection, malformed-response,
+oversized-response, invalid-input, and unknown errors are not cached.
+Stale-if-error may use a successful stale result for a provider timeout, but
+does not hide cancellation or deadline expiry of the caller's context. It
+never falls back to a stale negative or rate-limit entry.
 
 ## Lookup policies
 

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -24,7 +24,8 @@ go doc github.com/georgestarcher/pwhois
 
 Read the selected `go.mod` version and the project README. Do not copy future
 APIs from open issues or assume a generic WHOIS, IRR, or RDAP server accepts
-the PWHOIS query and response format.
+the PWHOIS query and response format. Team Cymru support uses the separate
+`TeamCymruProvider`; it is not a `WhoisServer` endpoint.
 
 ## Choose a lookup
 
@@ -38,6 +39,11 @@ the PWHOIS query and response format.
 Pass domain inputs to the high-level method instead of constructing wire text.
 ASN lookups accept decimal input with an optional `AS` prefix. The default IP
 batch limit is 500 addresses. Responses are limited to 8 MiB by default.
+
+For explicit BGP-origin enrichment from Team Cymru, use
+`TeamCymruProvider.LookupIPContext`. It accepts one or more IP addresses and
+returns `[]TeamCymruIPResult`. Do not route Team Cymru responses through the
+native PWHOIS parsers or treat its RIR allocation country code as geolocation.
 
 ## Connection and error handling
 
@@ -65,6 +71,12 @@ connection. A custom `ContextDialer` must itself be concurrency-safe and must
 honor its context. This hook is intended for deterministic tests and
 controlled transport integration.
 
+`TeamCymruProvider` follows the same owned-connection and concurrency model.
+Its zero value uses `whois.cymru.com:43`, a five-second timeout, a
+1,000-address batch limit, and the shared 8 MiB response limit. It sends one
+bulk request for all deduplicated inputs and does not automatically retry,
+fall back, or cache.
+
 `WhoisServer.MaxResponseBytes` bounds response data before parsing. Its zero
 value uses `DefaultMaxResponseBytes` (8 MiB), which provides more than 16 KiB
 per result in a maximum 500-address IP batch. Set a positive application-
@@ -74,12 +86,12 @@ returns a `*ResponseTooLargeError`. Detect it with
 `errors.Is(err, pwhois.ErrResponseTooLarge)`; do not compare error strings.
 
 Use `errors.Is` to classify every failure: `ErrInvalidInput`, `ErrConnection`,
-`ErrTimeout`, `ErrCanceled`, `ErrRateLimited`, `ErrResponseTooLarge`,
-`ErrMalformedResponse`, and `ErrNoRecords`. `Connect` and lookup failures are
-wrapped in `*OperationError`, so `errors.As` can retrieve the operation and
-configured endpoint without losing the underlying transport or parser cause.
-Do not compare error strings or expose full server response content in calling
-application logs.
+`ErrTimeout`, `ErrCanceled`, `ErrRateLimited`, `ErrProviderRejected`,
+`ErrResponseTooLarge`, `ErrMalformedResponse`, and `ErrNoRecords`. `Connect`
+and lookup failures are wrapped in `*OperationError`, so `errors.As` can
+retrieve the operation and configured endpoint without losing the underlying
+transport or parser cause. Do not compare error strings or expose full server
+response content in calling application logs.
 
 Handle connection, write, read, rate-limit, and parser errors as normal
 application outcomes. Do not silently retry rate-limit errors or treat a
@@ -98,6 +110,10 @@ integration, use one connected `WhoisServer` for one lookup and close its
 `LookupNetblockContext`. Supply a high-level lookup as the application's
 context-aware fetch operation and retain explicit source policy.
 
+`TeamCymruProvider.CacheKeySpec` builds the provider-specific cache identity.
+Configure a separate `SourceCachePolicy` for `TeamCymruSource`; do not reuse a
+native PWHOIS key or silently merge results from the two sources.
+
 If the application uses this cache contract, read the
 [cache contract guide](cache-contract.md). In particular, configure a policy
 for each source, version parser/result schemas in the key, inspect
@@ -106,18 +122,23 @@ response in `NormalizedResult`.
 
 ## Server and data boundaries
 
-`SetDefaultValues` configures `whois.pwhois.org:43`, the tested default. A
-different hostname alone does not establish compatibility with a generic WHOIS
-or IRR service. Public servers control their availability and rate limits.
+`SetDefaultValues` configures `whois.pwhois.org:43`, the tested native PWHOIS
+default. `TeamCymruProvider` explicitly configures the separate Team Cymru
+protocol. A different hostname alone does not establish compatibility with a
+generic WHOIS or IRR service. Public providers control their availability and
+rate limits, and port 43 sends queries in plaintext.
 
 Keep credentials, private addresses, live registry responses, contact data,
 and rate-limit details out of source code, committed fixtures, and prompts. Use
 synthetic/reserved documentation values such as `192.0.2.1` in examples.
+Only send an address to a third-party provider when the application's privacy
+policy permits it.
 
 ## Integration checklist
 
-1. Confirm that native PWHOIS is the required protocol and select one lookup.
-2. Inspect the chosen module version and its formatter and response type.
+1. Select native PWHOIS or the explicit Team Cymru provider based on the
+   required data source.
+2. Inspect the chosen module version, lookup method, and response type.
 3. Set application-appropriate timeout, response-size, and rate-limit policy.
 4. Classify every returned error with `errors.Is`, and test cancellation,
    malformed responses, and unavailable-server behavior in the application.

--- a/pwhois.go
+++ b/pwhois.go
@@ -45,6 +45,7 @@ var (
 	ErrTimeout           = errors.New("pwhois lookup timed out")
 	ErrCanceled          = errors.New("pwhois lookup canceled")
 	ErrRateLimited       = errors.New("pwhois server rate limit exceeded")
+	ErrProviderRejected  = errors.New("pwhois provider rejected query")
 	ErrResponseTooLarge  = errors.New("pwhois response exceeds maximum size")
 	ErrMalformedResponse = errors.New("pwhois malformed response")
 	ErrNoRecords         = errors.New("pwhois no records returned")

--- a/pwhois_json_test.go
+++ b/pwhois_json_test.go
@@ -56,6 +56,14 @@ func TestPublicJSONRecordContracts(t *testing.T) {
 			value: Netblock{},
 			keys:  []string{"create_date", "modify_date", "net_name", "net_range", "net_type", "register_date", "source", "update_date"},
 		},
+		{
+			name:  "TeamCymruIPResult",
+			value: TeamCymruIPResult{},
+			keys: []string{
+				"allocated_date", "as_name", "country_code", "endpoint", "fetched_at", "found",
+				"ip", "origin_asns", "prefix", "registry", "source",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/team_cymru.go
+++ b/team_cymru.go
@@ -250,10 +250,19 @@ func (provider TeamCymruProvider) LookupIPContext(ctx context.Context, values []
 }
 
 func isTeamCymruRateLimitedResponse(response string) bool {
-	lower := strings.ToLower(response)
-	return strings.Contains(lower, "query limit exceeded") ||
-		strings.Contains(lower, "rate limit") ||
-		strings.Contains(lower, "too many queries")
+	for _, line := range strings.Split(response, "\n") {
+		trimmed := strings.ToLower(strings.TrimSpace(line))
+		if strings.Contains(trimmed, "|") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "error:") &&
+			(strings.Contains(trimmed, "query limit exceeded") ||
+				strings.Contains(trimmed, "rate limit") ||
+				strings.Contains(trimmed, "too many queries")) {
+			return true
+		}
+	}
+	return false
 }
 
 func isTeamCymruRejectedResponse(response string) bool {
@@ -274,7 +283,6 @@ func parseTeamCymruIPResponse(requested []string, response, endpoint string, fet
 
 	requestedSet := make(map[string]struct{}, len(requested))
 	seen := make(map[string]bool, len(requested))
-	seenFound := make(map[string]bool, len(requested))
 	for _, value := range requested {
 		requestedSet[value] = struct{}{}
 	}
@@ -297,11 +305,10 @@ func parseTeamCymruIPResponse(requested []string, response, endpoint string, fet
 		if _, expected := requestedSet[result.IP]; !expected {
 			return nil, malformedResponseError(fmt.Errorf("Team Cymru response line %d returned unrequested IP", lineNumber+1))
 		}
-		if previousFound, duplicate := seenFound[result.IP]; duplicate && previousFound != result.Found {
-			return nil, malformedResponseError(fmt.Errorf("Team Cymru response line %d conflicts with an earlier result", lineNumber+1))
+		if seen[result.IP] {
+			return nil, malformedResponseError(fmt.Errorf("Team Cymru response line %d duplicates an earlier result", lineNumber+1))
 		}
 		seen[result.IP] = true
-		seenFound[result.IP] = result.Found
 		if result.Found {
 			foundCount++
 		}
@@ -374,6 +381,9 @@ func parseTeamCymruIPLine(line, endpoint string, fetchedAt time.Time) (TeamCymru
 	_, prefix, err := net.ParseCIDR(prefixField)
 	if err != nil {
 		return TeamCymruIPResult{}, fmt.Errorf("invalid BGP prefix")
+	}
+	if !prefix.Contains(ip) {
+		return TeamCymruIPResult{}, fmt.Errorf("BGP prefix does not contain the queried IP")
 	}
 
 	result.Found = true

--- a/team_cymru.go
+++ b/team_cymru.go
@@ -1,0 +1,409 @@
+package pwhois
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultTeamCymruServer is the documented Team Cymru origin-ASN mapping
+	// endpoint.
+	DefaultTeamCymruServer = "whois.cymru.com"
+	// DefaultTeamCymruPort is the documented TCP WHOIS service port.
+	DefaultTeamCymruPort = 43
+	// DefaultTeamCymruBatchMaxSize keeps one request below the provider's
+	// guidance to submit no more than a few thousand addresses per bulk run.
+	DefaultTeamCymruBatchMaxSize = 1000
+
+	// TeamCymruSource identifies Team Cymru results in provenance and cache
+	// keys.
+	TeamCymruSource = "team-cymru"
+	// TeamCymruProtocolVersion identifies the request protocol used in cache
+	// keys.
+	TeamCymruProtocolVersion = "cymru-whois-v1"
+	// TeamCymruParserVersion identifies the parser contract used in cache keys.
+	TeamCymruParserVersion = "cymru-ip-v1"
+	// TeamCymruResultSchemaVersion identifies the normalized result shape used
+	// in cache keys.
+	TeamCymruResultSchemaVersion = "cymru-ip-result-v1"
+)
+
+// TeamCymruProvider configures explicit Team Cymru IP-to-origin-ASN lookups.
+// It is separate from WhoisServer because Team Cymru's protocol and result
+// format are not native PWHOIS.
+type TeamCymruProvider struct {
+	Server       string
+	Port         int
+	BatchMaxSize int
+	Timeout      time.Duration
+	// MaxResponseBytes bounds the complete provider response before parsing. A
+	// value less than or equal to zero uses DefaultMaxResponseBytes.
+	MaxResponseBytes int64
+	// Dialer optionally replaces the default TCP dialer. It must honor context
+	// cancellation and be safe for concurrent use when the provider is shared.
+	Dialer ContextDialer
+}
+
+// TeamCymruIPResult is source-specific BGP-origin enrichment for one queried
+// IP address. CountryCode and Registry describe RIR allocation data and must
+// not be treated as IP geolocation.
+type TeamCymruIPResult struct {
+	IP            string    `json:"ip"`
+	Found         bool      `json:"found"`
+	OriginASNs    []uint32  `json:"origin_asns"`
+	Prefix        string    `json:"prefix"`
+	CountryCode   string    `json:"country_code"`
+	Registry      string    `json:"registry"`
+	AllocatedDate time.Time `json:"allocated_date"`
+	ASName        string    `json:"as_name"`
+	Source        string    `json:"source"`
+	Endpoint      string    `json:"endpoint"`
+	FetchedAt     time.Time `json:"fetched_at"`
+}
+
+func (provider TeamCymruProvider) configured() TeamCymruProvider {
+	if provider.Server == "" {
+		provider.Server = DefaultTeamCymruServer
+	}
+	if provider.Port == 0 {
+		provider.Port = DefaultTeamCymruPort
+	}
+	if provider.BatchMaxSize <= 0 {
+		provider.BatchMaxSize = DefaultTeamCymruBatchMaxSize
+	}
+	if provider.Timeout <= 0 {
+		provider.Timeout = time.Second * time.Duration(SocketTimeout)
+	}
+	if provider.MaxResponseBytes <= 0 {
+		provider.MaxResponseBytes = DefaultMaxResponseBytes
+	}
+	return provider
+}
+
+// ServerAddressString returns the configured Team Cymru TCP endpoint.
+func (provider TeamCymruProvider) ServerAddressString() string {
+	provider = provider.configured()
+	return net.JoinHostPort(provider.Server, strconv.Itoa(provider.Port))
+}
+
+func (provider TeamCymruProvider) operationError(operation string, err error) error {
+	return &OperationError{
+		Operation: operation,
+		Server:    provider.ServerAddressString(),
+		Err:       err,
+	}
+}
+
+func (provider TeamCymruProvider) dial(ctx context.Context) (net.Conn, error) {
+	if provider.Dialer != nil {
+		return provider.Dialer.DialContext(ctx, "tcp", provider.ServerAddressString())
+	}
+
+	dialer := &net.Dialer{
+		KeepAlive: time.Second * time.Duration(SocketKeepAlive),
+	}
+	return dialer.DialContext(ctx, "tcp", provider.ServerAddressString())
+}
+
+func normalizeTeamCymruIPs(values []string, batchMaxSize int) ([]string, error) {
+	if len(values) == 0 {
+		return nil, invalidInputError("at least one IP address is required")
+	}
+
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for index, value := range values {
+		ip := net.ParseIP(strings.TrimSpace(value))
+		if ip == nil {
+			return nil, invalidInputError(fmt.Sprintf("invalid IP address at position %d", index+1))
+		}
+		canonical := ip.String()
+		if _, found := seen[canonical]; found {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		normalized = append(normalized, canonical)
+	}
+
+	if len(normalized) > batchMaxSize {
+		return nil, invalidInputError(fmt.Sprintf("Team Cymru IP batch exceeds maximum of %d addresses", batchMaxSize))
+	}
+	return normalized, nil
+}
+
+func formatTeamCymruIPQuery(values []string) string {
+	var query strings.Builder
+	query.WriteString("begin\nverbose\nnoheader\n")
+	for _, value := range values {
+		query.WriteString(value)
+		query.WriteByte('\n')
+	}
+	query.WriteString("end\n")
+	return query.String()
+}
+
+// CacheKeySpec returns the source-aware key specification for a Team Cymru
+// lookup. It does not read or write a cache; the calling application still
+// selects an explicit CacheCoordinator policy.
+func (provider TeamCymruProvider) CacheKeySpec(values []string) (CacheKeySpec, error) {
+	provider = provider.configured()
+	normalized, err := normalizeTeamCymruIPs(values, provider.BatchMaxSize)
+	if err != nil {
+		return CacheKeySpec{}, err
+	}
+
+	return CacheKeySpec{
+		Source:              TeamCymruSource,
+		Endpoint:            provider.ServerAddressString(),
+		Protocol:            TeamCymruProtocolVersion,
+		NormalizedQuery:     strings.Join(normalized, "\n"),
+		Options:             map[string]string{"mode": "bulk-verbose", "header": "disabled"},
+		ParserVersion:       TeamCymruParserVersion,
+		ResultSchemaVersion: TeamCymruResultSchemaVersion,
+	}, nil
+}
+
+// LookupIPContext maps one or more IP addresses to Team Cymru BGP-origin data.
+// One TCP bulk request is used even for a single address so grouped callers do
+// not generate repeated individual WHOIS queries. Inputs are validated,
+// canonicalized, and deduplicated before the request.
+//
+// The call owns its connection, honors the shorter of the context deadline
+// and Timeout, applies MaxResponseBytes, and never retries or falls back to
+// native PWHOIS. A provider may be shared by concurrent callers when its
+// fields and custom Dialer are not mutated during use.
+func (provider TeamCymruProvider) LookupIPContext(ctx context.Context, values []string) ([]TeamCymruIPResult, error) {
+	const operation = "lookup Team Cymru IP-to-ASN"
+
+	provider = provider.configured()
+	if ctx == nil {
+		return nil, provider.operationError(operation, invalidInputError("context must not be nil"))
+	}
+	normalized, err := normalizeTeamCymruIPs(values, provider.BatchMaxSize)
+	if err != nil {
+		return nil, provider.operationError(operation, err)
+	}
+	query := formatTeamCymruIPQuery(normalized)
+
+	lookupCtx, cancel := context.WithTimeout(ctx, provider.Timeout)
+	defer cancel()
+
+	connection, err := provider.dial(lookupCtx)
+	if err != nil {
+		return nil, provider.operationError(operation, classifyContextTransportError(lookupCtx, err))
+	}
+	if connection == nil {
+		return nil, provider.operationError(operation, ErrConnection)
+	}
+	defer connection.Close()
+
+	stopCancellationClose := context.AfterFunc(lookupCtx, func() {
+		_ = connection.Close()
+	})
+	defer stopCancellationClose()
+
+	deadline, _ := lookupCtx.Deadline()
+	if err := connection.SetDeadline(deadline); err != nil {
+		return nil, provider.operationError(operation, classifyContextTransportError(lookupCtx, err))
+	}
+	written, err := io.WriteString(connection, query)
+	if err == nil && written != len(query) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		return nil, provider.operationError(operation, classifyContextTransportError(lookupCtx, err))
+	}
+
+	rawResponse, err := readBoundedResponse(connection, provider.MaxResponseBytes)
+	if err != nil {
+		if errors.Is(err, ErrResponseTooLarge) {
+			return nil, provider.operationError(operation, err)
+		}
+		return nil, provider.operationError(operation, classifyContextTransportError(lookupCtx, err))
+	}
+	if err := lookupCtx.Err(); err != nil {
+		return nil, provider.operationError(operation, classifyTransportError(err))
+	}
+
+	response := string(rawResponse)
+	switch {
+	case isTeamCymruRateLimitedResponse(response):
+		return nil, provider.operationError(operation, ErrRateLimited)
+	case isTeamCymruRejectedResponse(response):
+		return nil, provider.operationError(operation, ErrProviderRejected)
+	}
+
+	results, err := parseTeamCymruIPResponse(normalized, response, provider.ServerAddressString(), time.Now().UTC())
+	if err != nil {
+		return nil, provider.operationError(operation, err)
+	}
+	if err := lookupCtx.Err(); err != nil {
+		return nil, provider.operationError(operation, classifyTransportError(err))
+	}
+	return results, nil
+}
+
+func isTeamCymruRateLimitedResponse(response string) bool {
+	lower := strings.ToLower(response)
+	return strings.Contains(lower, "query limit exceeded") ||
+		strings.Contains(lower, "rate limit") ||
+		strings.Contains(lower, "too many queries")
+}
+
+func isTeamCymruRejectedResponse(response string) bool {
+	for _, line := range strings.Split(response, "\n") {
+		trimmed := strings.ToLower(strings.TrimSpace(line))
+		if strings.HasPrefix(trimmed, "error:") ||
+			strings.HasPrefix(trimmed, "invalid query") {
+			return true
+		}
+	}
+	return false
+}
+
+func parseTeamCymruIPResponse(requested []string, response, endpoint string, fetchedAt time.Time) ([]TeamCymruIPResult, error) {
+	if strings.TrimSpace(response) == "" {
+		return nil, noRecordsError("Team Cymru IP-to-ASN lookup")
+	}
+
+	requestedSet := make(map[string]struct{}, len(requested))
+	seen := make(map[string]bool, len(requested))
+	seenFound := make(map[string]bool, len(requested))
+	for _, value := range requested {
+		requestedSet[value] = struct{}{}
+	}
+
+	results := make([]TeamCymruIPResult, 0, len(requested))
+	foundCount := 0
+	for lineNumber, line := range strings.Split(response, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(strings.ToLower(trimmed), "bulk mode;") {
+			continue
+		}
+		if isTeamCymruHeader(trimmed) {
+			continue
+		}
+
+		result, err := parseTeamCymruIPLine(trimmed, endpoint, fetchedAt)
+		if err != nil {
+			return nil, malformedResponseError(fmt.Errorf("parse Team Cymru response line %d: %w", lineNumber+1, err))
+		}
+		if _, expected := requestedSet[result.IP]; !expected {
+			return nil, malformedResponseError(fmt.Errorf("Team Cymru response line %d returned unrequested IP", lineNumber+1))
+		}
+		if previousFound, duplicate := seenFound[result.IP]; duplicate && previousFound != result.Found {
+			return nil, malformedResponseError(fmt.Errorf("Team Cymru response line %d conflicts with an earlier result", lineNumber+1))
+		}
+		seen[result.IP] = true
+		seenFound[result.IP] = result.Found
+		if result.Found {
+			foundCount++
+		}
+		results = append(results, result)
+	}
+
+	if len(results) == 0 {
+		return nil, noRecordsError("Team Cymru IP-to-ASN lookup")
+	}
+	for _, value := range requested {
+		if !seen[value] {
+			return nil, malformedResponseError(fmt.Errorf("Team Cymru response omitted a requested IP"))
+		}
+	}
+	if foundCount == 0 {
+		return nil, noRecordsError("Team Cymru IP-to-ASN lookup")
+	}
+	return results, nil
+}
+
+func isTeamCymruHeader(line string) bool {
+	fields := strings.Split(line, "|")
+	if len(fields) < 2 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(fields[0]), "AS") &&
+		strings.EqualFold(strings.TrimSpace(fields[1]), "IP")
+}
+
+func parseTeamCymruIPLine(line, endpoint string, fetchedAt time.Time) (TeamCymruIPResult, error) {
+	fields := strings.SplitN(line, "|", 7)
+	if len(fields) < 7 {
+		return TeamCymruIPResult{}, fmt.Errorf("expected at least 7 pipe-delimited fields")
+	}
+	for index := 0; index < 6; index++ {
+		fields[index] = strings.TrimSpace(fields[index])
+	}
+
+	ip := net.ParseIP(fields[1])
+	if ip == nil {
+		return TeamCymruIPResult{}, fmt.Errorf("invalid IP field")
+	}
+
+	result := TeamCymruIPResult{
+		IP:        ip.String(),
+		Source:    TeamCymruSource,
+		Endpoint:  endpoint,
+		FetchedAt: fetchedAt,
+	}
+
+	asnField := fields[0]
+	prefixField := fields[2]
+	if strings.EqualFold(asnField, "NA") && strings.EqualFold(prefixField, "NA") {
+		return result, nil
+	}
+	if strings.EqualFold(asnField, "NA") || strings.EqualFold(prefixField, "NA") {
+		return TeamCymruIPResult{}, fmt.Errorf("inconsistent no-record fields")
+	}
+
+	for _, asnText := range strings.Fields(asnField) {
+		asn, err := strconv.ParseUint(asnText, 10, 32)
+		if err != nil {
+			return TeamCymruIPResult{}, fmt.Errorf("invalid origin ASN")
+		}
+		result.OriginASNs = append(result.OriginASNs, uint32(asn))
+	}
+	if len(result.OriginASNs) == 0 {
+		return TeamCymruIPResult{}, fmt.Errorf("missing origin ASN")
+	}
+	if _, _, err := net.ParseCIDR(prefixField); err != nil {
+		return TeamCymruIPResult{}, fmt.Errorf("invalid BGP prefix")
+	}
+
+	result.Found = true
+	result.Prefix = prefixField
+	result.CountryCode = normalizeTeamCymruOptionalField(fields[3])
+	result.Registry = strings.ToLower(normalizeTeamCymruOptionalField(fields[4]))
+
+	allocated := normalizeTeamCymruOptionalField(fields[5])
+	if allocated != "" {
+		parsed, err := time.Parse("2006-01-02", allocated)
+		if err != nil {
+			return TeamCymruIPResult{}, fmt.Errorf("invalid allocation date")
+		}
+		result.AllocatedDate = parsed
+	}
+
+	description := strings.TrimSpace(fields[6])
+	// A verbose response may retain an empty Info column even when the request
+	// supplied no per-IP metadata. Remove only that empty leading column while
+	// preserving any later pipe delimiters in the AS description.
+	if strings.HasPrefix(description, "|") {
+		description = strings.TrimSpace(strings.TrimPrefix(description, "|"))
+	}
+	result.ASName = normalizeTeamCymruOptionalField(description)
+	return result, nil
+}
+
+func normalizeTeamCymruOptionalField(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, "NA") {
+		return ""
+	}
+	return value
+}

--- a/team_cymru.go
+++ b/team_cymru.go
@@ -371,13 +371,14 @@ func parseTeamCymruIPLine(line, endpoint string, fetchedAt time.Time) (TeamCymru
 	if len(result.OriginASNs) == 0 {
 		return TeamCymruIPResult{}, fmt.Errorf("missing origin ASN")
 	}
-	if _, _, err := net.ParseCIDR(prefixField); err != nil {
+	_, prefix, err := net.ParseCIDR(prefixField)
+	if err != nil {
 		return TeamCymruIPResult{}, fmt.Errorf("invalid BGP prefix")
 	}
 
 	result.Found = true
-	result.Prefix = prefixField
-	result.CountryCode = normalizeTeamCymruOptionalField(fields[3])
+	result.Prefix = prefix.String()
+	result.CountryCode = strings.ToUpper(normalizeTeamCymruOptionalField(fields[3]))
 	result.Registry = strings.ToLower(normalizeTeamCymruOptionalField(fields[4]))
 
 	allocated := normalizeTeamCymruOptionalField(fields[5])

--- a/team_cymru_test.go
+++ b/team_cymru_test.go
@@ -1,0 +1,499 @@
+package pwhois
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const (
+	teamCymruSingleRequest = "begin\nverbose\nnoheader\n192.0.2.1\nend\n"
+	teamCymruBatchRequest  = "begin\nverbose\nnoheader\n192.0.2.1\n198.51.100.2\nend\n"
+	teamCymruSingleResult  = "64500 | 192.0.2.1 | 192.0.2.0/24 | ZZ | test | 2020-01-02 | EXAMPLE-AS - Example Network, ZZ"
+)
+
+func loopbackTeamCymruProvider(t *testing.T, script loopbackProtocolScript) (TeamCymruProvider, <-chan loopbackProtocolResult) {
+	t.Helper()
+
+	server, results := startLoopbackProtocolServer(t, script)
+	return TeamCymruProvider{
+		Server:           server.Server,
+		Port:             server.Port,
+		BatchMaxSize:     DefaultTeamCymruBatchMaxSize,
+		Timeout:          server.Timeout,
+		MaxResponseBytes: server.MaxResponseBytes,
+	}, results
+}
+
+func TestTeamCymruSingleAndBatchLookups(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputs          []string
+		expectedRequest string
+		response        string
+		check           func(*testing.T, []TeamCymruIPResult)
+	}{
+		{
+			name:            "single",
+			inputs:          []string{"192.0.2.1"},
+			expectedRequest: teamCymruSingleRequest,
+			response:        teamCymruSingleResult,
+			check: func(t *testing.T, results []TeamCymruIPResult) {
+				t.Helper()
+				if len(results) != 1 {
+					t.Fatalf("results = %+v", results)
+				}
+				result := results[0]
+				if !result.Found || result.IP != "192.0.2.1" || result.Prefix != "192.0.2.0/24" {
+					t.Fatalf("result = %+v", result)
+				}
+				if len(result.OriginASNs) != 1 || result.OriginASNs[0] != 64500 {
+					t.Fatalf("origin ASNs = %v", result.OriginASNs)
+				}
+				if result.CountryCode != "ZZ" || result.Registry != "test" ||
+					result.ASName != "EXAMPLE-AS - Example Network, ZZ" {
+					t.Fatalf("allocation metadata = %+v", result)
+				}
+				if want := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC); !result.AllocatedDate.Equal(want) {
+					t.Fatalf("allocated date = %v, want %v", result.AllocatedDate, want)
+				}
+			},
+		},
+		{
+			name:            "batch canonicalizes and deduplicates",
+			inputs:          []string{" 192.0.2.1 ", "198.51.100.2", "192.0.2.1"},
+			expectedRequest: teamCymruBatchRequest,
+			response: "Bulk mode; test fixture\n" +
+				"AS | IP | BGP Prefix | CC | Registry | Allocated | AS Name\n" +
+				"64500 64501 | 192.0.2.1 | 192.0.2.0/24 | ZZ | TEST | 2020-01-02 | EXAMPLE | NETWORK\n" +
+				"64502 | 198.51.100.2 | 198.51.100.0/24 | ZZ | TEST | NA | SECOND-AS",
+			check: func(t *testing.T, results []TeamCymruIPResult) {
+				t.Helper()
+				if len(results) != 2 {
+					t.Fatalf("results = %+v", results)
+				}
+				if got := results[0].OriginASNs; len(got) != 2 || got[0] != 64500 || got[1] != 64501 {
+					t.Fatalf("multi-origin ASNs = %v", got)
+				}
+				if results[0].ASName != "EXAMPLE | NETWORK" {
+					t.Fatalf("delimiter-containing AS name = %q", results[0].ASName)
+				}
+				if !results[1].AllocatedDate.IsZero() {
+					t.Fatalf("NA allocation date = %v, want zero", results[1].AllocatedDate)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider, protocolResult := loopbackTeamCymruProvider(t, loopbackProtocolScript{
+				expectedRequest: test.expectedRequest,
+				responseChunks:  []string{test.response},
+			})
+			started := time.Now().UTC()
+
+			results, err := provider.LookupIPContext(context.Background(), test.inputs)
+			if err != nil {
+				t.Fatalf("LookupIPContext: %v", err)
+			}
+			finished := time.Now().UTC()
+			test.check(t, results)
+			for _, result := range results {
+				if result.Source != TeamCymruSource || result.Endpoint != provider.ServerAddressString() {
+					t.Fatalf("provenance = %+v", result)
+				}
+				if result.FetchedAt.Before(started) || result.FetchedAt.After(finished) {
+					t.Fatalf("fetched at = %v, want between %v and %v", result.FetchedAt, started, finished)
+				}
+			}
+			verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, test.expectedRequest)
+		})
+	}
+}
+
+func TestParseTeamCymruResponseFailures(t *testing.T) {
+	fetchedAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		requested []string
+		response  string
+		wantError error
+	}{
+		{
+			name:      "empty",
+			requested: []string{"192.0.2.1"},
+			response:  "",
+			wantError: ErrNoRecords,
+		},
+		{
+			name:      "explicit no record",
+			requested: []string{"192.0.2.1"},
+			response:  "NA | 192.0.2.1 | NA | NA | NA | NA | NA",
+			wantError: ErrNoRecords,
+		},
+		{
+			name:      "too few fields",
+			requested: []string{"192.0.2.1"},
+			response:  "64500 | 192.0.2.1",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "inconsistent no record",
+			requested: []string{"192.0.2.1"},
+			response:  "NA | 192.0.2.1 | 192.0.2.0/24 | ZZ | test | NA | NA",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "invalid ASN",
+			requested: []string{"192.0.2.1"},
+			response:  "not-an-asn | 192.0.2.1 | 192.0.2.0/24 | ZZ | test | NA | Example",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "invalid prefix",
+			requested: []string{"192.0.2.1"},
+			response:  "64500 | 192.0.2.1 | not-a-prefix | ZZ | test | NA | Example",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "invalid allocation date",
+			requested: []string{"192.0.2.1"},
+			response:  "64500 | 192.0.2.1 | 192.0.2.0/24 | ZZ | test | yesterday | Example",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "unrequested IP",
+			requested: []string{"192.0.2.1"},
+			response:  "64500 | 198.51.100.2 | 198.51.100.0/24 | ZZ | test | NA | Example",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "missing requested IP is partial failure",
+			requested: []string{"192.0.2.1", "198.51.100.2"},
+			response:  teamCymruSingleResult,
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "conflicting duplicate",
+			requested: []string{"192.0.2.1"},
+			response: teamCymruSingleResult +
+				"\nNA | 192.0.2.1 | NA | NA | NA | NA | NA",
+			wantError: ErrMalformedResponse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseTeamCymruIPResponse(test.requested, test.response, "test.example:43", fetchedAt)
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("parse error = %v, want %v", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestParseTeamCymruResponsePreservesPerIPNoRecord(t *testing.T) {
+	fetchedAt := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	results, err := parseTeamCymruIPResponse(
+		[]string{"192.0.2.1", "198.51.100.2"},
+		teamCymruSingleResult+"\nNA | 198.51.100.2 | NA | NA | NA | NA | NA",
+		"test.example:43",
+		fetchedAt,
+	)
+	if err != nil {
+		t.Fatalf("parse mixed response: %v", err)
+	}
+	if len(results) != 2 || !results[0].Found || results[1].Found ||
+		results[1].IP != "198.51.100.2" || !results[1].FetchedAt.Equal(fetchedAt) {
+		t.Fatalf("mixed results = %+v", results)
+	}
+}
+
+func TestTeamCymruProviderResponseErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  string
+		wantError error
+	}{
+		{name: "rate limit", response: "Error: Query limit exceeded", wantError: ErrRateLimited},
+		{name: "provider rejected", response: "Error: invalid query option", wantError: ErrProviderRejected},
+		{name: "no records", response: "", wantError: ErrNoRecords},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider, protocolResult := loopbackTeamCymruProvider(t, loopbackProtocolScript{
+				expectedRequest: teamCymruSingleRequest,
+				responseChunks:  []string{test.response},
+			})
+			_, err := provider.LookupIPContext(context.Background(), []string{"192.0.2.1"})
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("lookup error = %v, want %v", err, test.wantError)
+			}
+			var operationError *OperationError
+			if !errors.As(err, &operationError) || operationError.Operation != "lookup Team Cymru IP-to-ASN" {
+				t.Fatalf("operation error = %#v", operationError)
+			}
+			verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, teamCymruSingleRequest)
+		})
+	}
+}
+
+func TestTeamCymruProviderCancellationAndTimeout(t *testing.T) {
+	tests := []struct {
+		name      string
+		context   func() (context.Context, context.CancelFunc)
+		timeout   time.Duration
+		wantError error
+	}{
+		{
+			name: "caller cancellation",
+			context: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				time.AfterFunc(50*time.Millisecond, cancel)
+				return ctx, cancel
+			},
+			timeout:   2 * time.Second,
+			wantError: ErrCanceled,
+		},
+		{
+			name: "provider timeout",
+			context: func() (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+			timeout:   50 * time.Millisecond,
+			wantError: ErrTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider, protocolResult := loopbackTeamCymruProvider(t, loopbackProtocolScript{
+				expectedRequest: teamCymruSingleRequest,
+				noResponse:      true,
+			})
+			provider.Timeout = test.timeout
+			ctx, cancel := test.context()
+			defer cancel()
+
+			_, err := provider.LookupIPContext(ctx, []string{"192.0.2.1"})
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("lookup error = %v, want %v", err, test.wantError)
+			}
+			verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, teamCymruSingleRequest)
+		})
+	}
+}
+
+func TestTeamCymruProviderBoundsResponse(t *testing.T) {
+	provider, protocolResult := loopbackTeamCymruProvider(t, loopbackProtocolScript{
+		expectedRequest: teamCymruSingleRequest,
+		responseChunks:  []string{teamCymruSingleResult},
+	})
+	provider.MaxResponseBytes = int64(len(teamCymruSingleResult) - 1)
+
+	_, err := provider.LookupIPContext(context.Background(), []string{"192.0.2.1"})
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("lookup error = %v, want ErrResponseTooLarge", err)
+	}
+	var sizeError *ResponseTooLargeError
+	if !errors.As(err, &sizeError) || sizeError.Limit != provider.MaxResponseBytes {
+		t.Fatalf("size error = %#v", sizeError)
+	}
+	verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, teamCymruSingleRequest)
+}
+
+type countingContextDialer struct {
+	calls atomic.Int64
+}
+
+func (dialer *countingContextDialer) DialContext(context.Context, string, string) (net.Conn, error) {
+	dialer.calls.Add(1)
+	return nil, fmt.Errorf("unexpected dial")
+}
+
+func TestTeamCymruProviderValidatesBeforeDial(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputs   []string
+		batchMax int
+	}{
+		{name: "empty", inputs: nil, batchMax: 1000},
+		{name: "invalid IP", inputs: []string{"not-an-ip"}, batchMax: 1000},
+		{name: "batch over limit", inputs: []string{"192.0.2.1", "198.51.100.2"}, batchMax: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dialer := &countingContextDialer{}
+			provider := TeamCymruProvider{BatchMaxSize: test.batchMax, Dialer: dialer}
+			_, err := provider.LookupIPContext(context.Background(), test.inputs)
+			if !errors.Is(err, ErrInvalidInput) {
+				t.Fatalf("lookup error = %v, want ErrInvalidInput", err)
+			}
+			if calls := dialer.calls.Load(); calls != 0 {
+				t.Fatalf("dial calls = %d, want 0", calls)
+			}
+		})
+	}
+}
+
+func TestTeamCymruProviderCanonicalizesIPv6(t *testing.T) {
+	normalized, err := normalizeTeamCymruIPs(
+		[]string{"2001:0db8:0000:0000:0000:0000:0000:0001", "2001:db8::1"},
+		DefaultTeamCymruBatchMaxSize,
+	)
+	if err != nil {
+		t.Fatalf("normalize IPv6: %v", err)
+	}
+	if len(normalized) != 1 || normalized[0] != "2001:db8::1" {
+		t.Fatalf("normalized IPv6 = %v", normalized)
+	}
+}
+
+func TestTeamCymruCacheKeyIsSourceSpecific(t *testing.T) {
+	provider := TeamCymruProvider{}
+	spec, err := provider.CacheKeySpec([]string{"192.0.2.1", "192.0.2.1"})
+	if err != nil {
+		t.Fatalf("CacheKeySpec: %v", err)
+	}
+	if spec.Source != TeamCymruSource || spec.Endpoint != "whois.cymru.com:43" ||
+		spec.Protocol != TeamCymruProtocolVersion || spec.NormalizedQuery != "192.0.2.1" {
+		t.Fatalf("cache spec = %+v", spec)
+	}
+
+	cymruKey, err := CanonicalCacheKey(spec)
+	if err != nil {
+		t.Fatalf("Team Cymru key: %v", err)
+	}
+	pwhoisSpec := spec
+	pwhoisSpec.Source = "pwhois"
+	pwhoisSpec.Endpoint = "whois.pwhois.org:43"
+	pwhoisSpec.Protocol = "pwhois"
+	pwhoisKey, err := CanonicalCacheKey(pwhoisSpec)
+	if err != nil {
+		t.Fatalf("PWHOIS key: %v", err)
+	}
+	if cymruKey == pwhoisKey || !strings.HasPrefix(cymruKey, "pwhois-cache:v1:team-cymru:") {
+		t.Fatalf("source-specific keys = %q and %q", cymruKey, pwhoisKey)
+	}
+}
+
+func TestTeamCymruProviderRejectedErrorClassification(t *testing.T) {
+	err := &OperationError{Operation: "lookup Team Cymru IP-to-ASN", Err: ErrProviderRejected}
+	if got := ClassifyProviderError(err); got != ProviderErrorRejected {
+		t.Fatalf("provider class = %q, want %q", got, ProviderErrorRejected)
+	}
+	if sentinel := providerErrorSentinel(ProviderErrorRejected); !errors.Is(sentinel, ErrProviderRejected) {
+		t.Fatalf("provider sentinel = %v, want ErrProviderRejected", sentinel)
+	}
+}
+
+func TestCacheCoordinatorDoesNotCacheTeamCymruRejection(t *testing.T) {
+	clock := &fakeCacheClock{now: cacheTestTime}
+	cache := newFakeCache()
+	coordinator, err := NewCacheCoordinator(CacheCoordinatorConfig{
+		Cache: cache,
+		Clock: clock,
+		SourcePolicies: map[string]SourceCachePolicy{
+			TeamCymruSource: {
+				SuccessTTL:     4 * time.Hour,
+				NoRecordsTTL:   10 * time.Minute,
+				RateLimitedTTL: time.Minute,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewCacheCoordinator: %v", err)
+	}
+	spec, err := (TeamCymruProvider{}).CacheKeySpec([]string{"192.0.2.1"})
+	if err != nil {
+		t.Fatalf("CacheKeySpec: %v", err)
+	}
+	request := CacheRequest{Key: spec, Policy: CachePolicyReadThrough}
+	fetchCalls := 0
+	fetch := func(context.Context) (CacheFetchResult, error) {
+		fetchCalls++
+		return CacheFetchResult{}, ErrProviderRejected
+	}
+
+	for attempt := 0; attempt < 2; attempt++ {
+		if _, err := coordinator.Lookup(context.Background(), request, fetch); !errors.Is(err, ErrProviderRejected) {
+			t.Fatalf("Lookup() error = %v, want ErrProviderRejected", err)
+		}
+	}
+	if fetchCalls != 2 {
+		t.Fatalf("fetch calls = %d, want uncached rejection on both attempts", fetchCalls)
+	}
+	_, setCalls := cache.counts()
+	if setCalls != 0 {
+		t.Fatalf("cache writes = %d, want 0", setCalls)
+	}
+}
+
+type successfulTeamCymruDialer struct {
+	calls  atomic.Int64
+	errors chan error
+}
+
+func (dialer *successfulTeamCymruDialer) DialContext(context.Context, string, string) (net.Conn, error) {
+	dialer.calls.Add(1)
+	client, provider := net.Pipe()
+	go func() {
+		defer provider.Close()
+		request := make([]byte, len(teamCymruSingleRequest))
+		if _, err := io.ReadFull(provider, request); err != nil {
+			dialer.errors <- err
+			return
+		}
+		if string(request) != teamCymruSingleRequest {
+			dialer.errors <- fmt.Errorf("request = %q", request)
+			return
+		}
+		_, err := io.WriteString(provider, teamCymruSingleResult)
+		dialer.errors <- err
+	}()
+	return client, nil
+}
+
+func TestTeamCymruProviderIsSafeForConcurrentUse(t *testing.T) {
+	const lookups = 16
+
+	dialer := &successfulTeamCymruDialer{errors: make(chan error, lookups)}
+	provider := TeamCymruProvider{Dialer: dialer}
+	lookupErrors := make(chan error, lookups)
+	var wait sync.WaitGroup
+
+	for index := 0; index < lookups; index++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			results, err := provider.LookupIPContext(context.Background(), []string{"192.0.2.1"})
+			if err == nil && (len(results) != 1 || results[0].IP != "192.0.2.1") {
+				err = fmt.Errorf("unexpected results: %+v", results)
+			}
+			lookupErrors <- err
+		}()
+	}
+	wait.Wait()
+
+	for index := 0; index < lookups; index++ {
+		if err := <-lookupErrors; err != nil {
+			t.Errorf("concurrent lookup: %v", err)
+		}
+		if err := <-dialer.errors; err != nil {
+			t.Errorf("concurrent provider: %v", err)
+		}
+	}
+	if got := dialer.calls.Load(); got != lookups {
+		t.Fatalf("dial calls = %d, want %d independent connections", got, lookups)
+	}
+}

--- a/team_cymru_test.go
+++ b/team_cymru_test.go
@@ -182,10 +182,29 @@ func TestParseTeamCymruResponseFailures(t *testing.T) {
 			wantError: ErrMalformedResponse,
 		},
 		{
-			name:      "conflicting duplicate",
+			name:      "duplicate with different Found state",
 			requested: []string{"192.0.2.1"},
 			response: teamCymruSingleResult +
 				"\nNA | 192.0.2.1 | NA | NA | NA | NA | NA",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "duplicate with different origin data",
+			requested: []string{"192.0.2.1"},
+			response: teamCymruSingleResult +
+				"\n64501 | 192.0.2.1 | 192.0.2.0/24 | ZZ | test | 2020-01-02 | OTHER-AS",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "prefix does not contain IP",
+			requested: []string{"192.0.2.1"},
+			response:  "64500 | 192.0.2.1 | 198.51.100.0/24 | ZZ | test | NA | Example",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "prefix address family differs",
+			requested: []string{"192.0.2.1"},
+			response:  "64500 | 192.0.2.1 | 2001:db8::/32 | ZZ | test | NA | Example",
 			wantError: ErrMalformedResponse,
 		},
 	}
@@ -245,6 +264,23 @@ func TestTeamCymruProviderResponseErrors(t *testing.T) {
 			verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, teamCymruSingleRequest)
 		})
 	}
+}
+
+func TestTeamCymruRateLimitPhraseInsideASNameIsData(t *testing.T) {
+	response := "64500 | 192.0.2.1 | 192.0.2.0/24 | ZZ | test | 2020-01-02 | RATE LIMIT RESEARCH NETWORK"
+	provider, protocolResult := loopbackTeamCymruProvider(t, loopbackProtocolScript{
+		expectedRequest: teamCymruSingleRequest,
+		responseChunks:  []string{response},
+	})
+
+	results, err := provider.LookupIPContext(context.Background(), []string{"192.0.2.1"})
+	if err != nil {
+		t.Fatalf("LookupIPContext: %v", err)
+	}
+	if len(results) != 1 || results[0].ASName != "RATE LIMIT RESEARCH NETWORK" {
+		t.Fatalf("results = %+v", results)
+	}
+	verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, teamCymruSingleRequest)
 }
 
 func TestTeamCymruProviderCancellationAndTimeout(t *testing.T) {


### PR DESCRIPTION
## Summary

- add an explicit `TeamCymruProvider` for source-specific IP-to-origin-ASN and prefix enrichment
- use one context-aware bulk TCP request for single or grouped lookups, with caller-configurable batch, deadline, endpoint, and response bounds
- parse Team Cymru pipe-delimited responses defensively, including multi-origin results, per-IP no-record rows, truncated/partial responses, and delimiter-containing AS names
- preserve source, endpoint, allocation metadata, and fetch-time provenance without treating country codes as geolocation
- add source-aware cache key identity and a stable, non-cacheable `ErrProviderRejected` class
- document the plaintext third-party boundary, explicit cache/rate-limit policy, and separation from native PWHOIS

## Provider policy

The implementation follows Team Cymru's documented bulk request guidance and never silently falls back to native PWHOIS, retries, caches, or merges provider claims. Required tests use synthetic reserved addresses and loopback or injected connections only.

Reference: https://www.team-cymru.com/ip-asn-mapping

## Validation

- `go test ./...`
- `go test -run 'TestTeamCymru|TestParseTeamCymru|TestCacheCoordinatorDoesNotCacheTeamCymru' -count=20 ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go mod tidy`
- `go mod verify`
- `git diff --check`

Closes #51
Closes #10