### PR TITLE
Add explicit RISwhois observed-route provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,11 @@ another application must start with
 ## Scope and contracts
 
 - `pwhois` supports native PWHOIS IP, RouteView, registry, and netblock queries
-  plus the explicit `TeamCymruProvider` IP-to-ASN protocol. It is not a generic
-  WHOIS, IRR, or RDAP client. Changing only `WhoisServer.Server` or a provider
-  hostname does not establish compatibility with another response format; add
-  a source-specific implementation and tests first.
+  plus the explicit `TeamCymruProvider` IP-to-ASN and `RISWhoisProvider`
+  observed-route protocols. It is not a generic WHOIS, IRR, or RDAP client.
+  Changing only `WhoisServer.Server` or a provider hostname does not establish
+  compatibility with another response format; add a source-specific
+  implementation and tests first.
 - The exported Go API, JSON field names, README, and deterministic tests are
   consumer-facing contracts. Keep them aligned when behavior changes. Preserve
   the serialization conventions corrected in #22 and #25 deliberately; use
@@ -42,6 +43,9 @@ another application must start with
 - `TeamCymruProvider` is always explicit, uses one bulk request for grouped
   inputs, and never falls back to native PWHOIS. Its country and registry
   fields are allocation metadata, not geolocation.
+- `RISWhoisProvider` is always explicit, uses longest-match IP or exact-match
+  prefix queries, and never falls back. Its output is observed BGP evidence
+  from RIPE RIS collectors, not RIR registration, geolocation, or IRR policy.
 - Respect server rate limits. Rate-limit responses and network errors are
   normal caller-visible outcomes, not conditions to hide with automatic retry.
 
@@ -51,7 +55,7 @@ another application must start with
   pull request. Use `go test -race ./...` when changing concurrency or network
   behavior.
 - Default tests must be deterministic and must not contact public PWHOIS, Team
-  Cymru, or other provider servers. Native PWHOIS live checks are opt-in:
+  Cymru, RISwhois, or other provider servers. Native PWHOIS live checks are opt-in:
   `go test -tags=integration ./...`.
 - Use reserved and synthetic addresses, ASNs, organizations, and response data
   in tests and documentation. Never commit live/private registry responses,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ Thanks for improving `pwhois`.
 
 `pwhois` is a Go client and parser for native PWHOIS IP, RouteView, registry,
 and netblock queries plus explicit source-specific providers such as Team
-Cymru IP-to-ASN mapping. It is not a generic WHOIS, IRR, or RDAP client. Keep
-network policy, retries, logging, storage, scheduling, and application actions
-in the consuming application.
+Cymru IP-to-ASN mapping and RIPE RISwhois observed routes. It is not a generic
+WHOIS, IRR, or RDAP client. Keep network policy, retries, logging, storage,
+scheduling, and application actions in the consuming application.
 
 ## Before opening a pull request
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 `pwhois` is a Go module for querying a [PWHOIS](https://pwhois.org/)
 server and parsing its IP, routing, registry, and netblock responses. It also
-provides an explicit, source-specific client for
-[Team Cymru IP-to-ASN mapping](https://www.team-cymru.com/ip-asn-mapping).
+provides explicit, source-specific clients for
+[Team Cymru IP-to-ASN mapping](https://www.team-cymru.com/ip-asn-mapping) and
+[RIPE RISwhois observed BGP routes](https://ris.ripe.net/docs/ris-whois/).
 
 Created by George Starcher. The implementation references the original [`whob` source code](https://github.com/irr/whob/blob/master/whob).
 
@@ -17,6 +18,7 @@ Created by George Starcher. The implementation references the original [`whob` s
 - Registry data for an ASN
 - Netblocks announced by an ASN
 - Team Cymru IP-to-origin-ASN and prefix enrichment
+- RIPE RISwhois observed prefix, origin ASN, and collector evidence
 
 ## Install
 
@@ -149,6 +151,8 @@ maintainers should use the [maintainer guide](AGENTS.md).
 | RouteView | `LookupRouteViewContext` | `BGPRoutes` |
 | Registry | `LookupRegistryContext` | `RegistryRecord` |
 | Netblock | `LookupNetblockContext` | `NetblockRecord` |
+| Team Cymru IP-to-ASN | `TeamCymruProvider.LookupIPContext` | `[]TeamCymruIPResult` |
+| RISwhois observed route | `RISWhoisProvider.LookupRouteContext` | `[]RISWhoisRouteResult` |
 
 ## Team Cymru IP-to-ASN provider
 
@@ -189,18 +193,60 @@ Port 43 traffic is plaintext. Do not send an address to this third-party
 provider unless the calling application's privacy and data-handling policy
 allows it.
 
+## RIPE RISwhois observed-route provider
+
+`RISWhoisProvider` queries the most recently collected BGP routing tables
+exposed by RIPE RISwhois. An IP address requests all longest-match origins; a
+CIDR prefix requests exact matches. Multiple-origin results remain separate.
+The result exposes the matched prefix, origin ASN, descriptions, collector
+visibility, RIS peer count, provider observation timestamps, and all ordered
+values for every RPSL attribute, with explicit source, endpoint, and client
+fetch-time provenance.
+
+```go
+provider := pwhois.RISWhoisProvider{}
+routes, err := provider.LookupRouteContext(
+	context.Background(),
+	"192.0.2.1",
+)
+```
+
+The zero value uses `riswhois.ripe.net:43`, a five-second timeout, and the
+shared 8 MiB response limit. The provider never retries, falls back to another
+source, or automatically caches results. It sends `-M` for an IP longest-match
+query and `-x` for an exact prefix query, preserving multiple origins rather
+than selecting only the majority origin.
+
+RISwhois data is observed BGP routing evidence from RIPE RIS collectors. It is
+not RIR allocation or ownership data, geolocation, or an Internet Routing
+Registry statement of published routing policy. `FirstObserved` and
+`LastObserved` are timestamps supplied by the provider; `FetchedAt` is when
+this client received the response.
+
+`RISWhoisProvider.CacheKeySpec` separates the source, endpoint, IP-versus-prefix
+match mode, protocol, parser, and result schema. The application must still
+configure an explicit `SourceCachePolicy`. A reasonable short-lived starting
+policy for operational enrichment is a 15-minute successful-result TTL,
+5-minute no-record TTL, 1-minute rate-limit TTL, and at most 30 minutes of
+successful stale data; applications needing fresher routing evidence should
+shorten or bypass that cache deliberately.
+
+Port 43 traffic is plaintext. Do not send an address or prefix to this
+third-party provider unless the calling application's privacy and data-handling
+policy allows it.
+
 ## Providers and servers
 
 `SetDefaultValues` configures `whois.pwhois.org:43`. You can set `WhoisServer.Server` and `WhoisServer.Port` before calling `Connect`, but compatibility with alternative servers is not yet validated. Availability and rate limits are controlled by each server operator.
 
-`TeamCymruProvider` is the only additional protocol-specific provider
-currently implemented. Generic WHOIS, IRR, and RDAP endpoints are not
-drop-in-compatible with either client.
+`TeamCymruProvider` and `RISWhoisProvider` are separate protocol-specific
+providers. Generic WHOIS, IRR, and RDAP endpoints are not drop-in-compatible
+with these clients.
 
 ## Development
 
-The default checks are deterministic and do not contact public PWHOIS or Team
-Cymru servers:
+The default checks are deterministic and do not contact public PWHOIS, Team
+Cymru, or RISwhois servers:
 
 ```shell
 go test ./...
@@ -227,12 +273,12 @@ The live tests depend on the public service's availability, response data, and r
 
 The explicit JSON-tagged data records (`WhoIs`, `BGPRoute`, `BGPRoutes`,
 `RegistryRecord`, `Registry`, `NetblockRecord`, `Netblock`, and
-`TeamCymruIPResult`) use normalized snake_case keys and are covered by
-serialization tests. Postal codes are text so leading zeros and alphanumeric
-values are preserved.
+`TeamCymruIPResult`, `RISWhoisObservation`, and `RISWhoisRouteResult`) use
+normalized snake_case keys and are covered by serialization tests. Postal
+codes are text so leading zeros and alphanumeric values are preserved.
 
-`WhoisServer`, `TeamCymruProvider`, and the channel response wrappers are
-connection/control types, not JSON output contracts.
+`WhoisServer`, `TeamCymruProvider`, `RISWhoisProvider`, and the channel response
+wrappers are connection/control types, not JSON output contracts.
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,9 +11,10 @@ synthetic reproduction.
 ## Project scope
 
 This project supports native PWHOIS IP, RouteView, registry, and netblock
-queries plus its documented source-specific providers. Generic WHOIS, IRR,
-and RDAP protocols are outside its current scope; changing only the server
-hostname does not make them compatible.
+queries plus its documented source-specific providers. RISwhois support is
+observed BGP evidence and does not make this a generic IRR client. Generic
+WHOIS, IRR, and RDAP protocols are outside its current scope; changing only
+the server hostname does not make them compatible.
 
 ## Sensitive data and security
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,10 +27,10 @@ are opt-in:
 go test -tags=integration ./...
 ```
 
-Required native PWHOIS and Team Cymru protocol coverage uses only scripted
-IPv4 loopback servers or injected connections. It exercises real TCP connect,
-request, response, EOF, timeout, cancellation, response bounds, and connection
-cleanup without depending on a public service.
+Required native PWHOIS, Team Cymru, and RISwhois protocol coverage uses only
+scripted IPv4 loopback servers or injected connections. It exercises real TCP
+connect, request, response, EOF, timeout, cancellation, response bounds, and
+connection cleanup without depending on a public service.
 
 The repository does not yet have a canonical documentation-validation command;
 that work is tracked in issue #28.

--- a/docs/cache-contract.md
+++ b/docs/cache-contract.md
@@ -11,9 +11,10 @@ The cache API separates three responsibilities:
 
 This is cache infrastructure, not an implicit wrapper around the high-level
 provider clients. Applications may use the native PWHOIS context methods or
-`TeamCymruProvider.LookupIPContext` inside their context-aware fetch operation,
-but they must still select a source, cache policy, and normalized result
-explicitly.
+`TeamCymruProvider.LookupIPContext` or
+`RISWhoisProvider.LookupRouteContext` inside their context-aware fetch
+operation, but they must still select a source, cache policy, and normalized
+result explicitly.
 The deprecated channel-based lookup methods continue to require a caller-owned
 connection.
 
@@ -57,6 +58,14 @@ oversized-response, invalid-input, and unknown errors are not cached.
 Stale-if-error may use a successful stale result for a provider timeout, but
 does not hide cancellation or deadline expiry of the caller's context. It
 never falls back to a stale negative or rate-limit entry.
+
+Provider freshness differs by source. In particular, RISwhois reports the most
+recently collected RIPE RIS routing tables, so its cache must not share a key
+or policy with native PWHOIS, Team Cymru, registration, or future IRR data.
+For operational enrichment, a 15-minute success TTL, 5-minute no-record TTL,
+1-minute rate-limit TTL, and 30-minute maximum successful-stale window are a
+reasonable starting point. Applications using routing changes for alerts or
+decisions should choose a shorter TTL or bypass caching explicitly.
 
 ## Lookup policies
 

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -25,7 +25,8 @@ go doc github.com/georgestarcher/pwhois
 Read the selected `go.mod` version and the project README. Do not copy future
 APIs from open issues or assume a generic WHOIS, IRR, or RDAP server accepts
 the PWHOIS query and response format. Team Cymru support uses the separate
-`TeamCymruProvider`; it is not a `WhoisServer` endpoint.
+`TeamCymruProvider`, and RISwhois support uses `RISWhoisProvider`; neither is
+a `WhoisServer` endpoint.
 
 ## Choose a lookup
 
@@ -44,6 +45,13 @@ For explicit BGP-origin enrichment from Team Cymru, use
 `TeamCymruProvider.LookupIPContext`. It accepts one or more IP addresses and
 returns `[]TeamCymruIPResult`. Do not route Team Cymru responses through the
 native PWHOIS parsers or treat its RIR allocation country code as geolocation.
+
+For observed BGP route evidence from RIPE RIS collectors, use
+`RISWhoisProvider.LookupRouteContext`. It accepts one IP address or CIDR prefix
+and returns every matching `RISWhoisRouteResult`. IP queries request all
+longest-match origins; prefix queries request exact matches. These are
+observations from collected routing tables, not RIR registration, geolocation,
+or published IRR policy.
 
 ## Connection and error handling
 
@@ -76,6 +84,11 @@ Its zero value uses `whois.cymru.com:43`, a five-second timeout, a
 1,000-address batch limit, and the shared 8 MiB response limit. It sends one
 bulk request for all deduplicated inputs and does not automatically retry,
 fall back, or cache.
+
+`RISWhoisProvider` also follows that owned-connection and concurrency model.
+Its zero value uses `riswhois.ripe.net:43`, a five-second timeout, and the
+shared 8 MiB response limit. It performs one query, preserves multiple origins,
+and does not automatically retry, fall back, or cache.
 
 `WhoisServer.MaxResponseBytes` bounds response data before parsing. Its zero
 value uses `DefaultMaxResponseBytes` (8 MiB), which provides more than 16 KiB
@@ -114,6 +127,13 @@ context-aware fetch operation and retain explicit source policy.
 Configure a separate `SourceCachePolicy` for `TeamCymruSource`; do not reuse a
 native PWHOIS key or silently merge results from the two sources.
 
+`RISWhoisProvider.CacheKeySpec` also records whether the normalized query is a
+longest-match IP lookup or an exact prefix lookup. Configure a separate policy
+for `RISWhoisSource`. A 15-minute success TTL, 5-minute no-record TTL,
+1-minute rate-limit TTL, and 30-minute maximum successful-stale window are a
+reasonable short-lived starting policy; callers needing current routing
+evidence should shorten or bypass it.
+
 If the application uses this cache contract, read the
 [cache contract guide](cache-contract.md). In particular, configure a policy
 for each source, version parser/result schemas in the key, inspect
@@ -124,9 +144,10 @@ response in `NormalizedResult`.
 
 `SetDefaultValues` configures `whois.pwhois.org:43`, the tested native PWHOIS
 default. `TeamCymruProvider` explicitly configures the separate Team Cymru
-protocol. A different hostname alone does not establish compatibility with a
-generic WHOIS or IRR service. Public providers control their availability and
-rate limits, and port 43 sends queries in plaintext.
+protocol, and `RISWhoisProvider` explicitly configures RISwhois RPSL routing
+observations. A different hostname alone does not establish compatibility with
+a generic WHOIS or IRR service. Public providers control their availability
+and rate limits, and port 43 sends queries in plaintext.
 
 Keep credentials, private addresses, live registry responses, contact data,
 and rate-limit details out of source code, committed fixtures, and prompts. Use
@@ -136,8 +157,8 @@ policy permits it.
 
 ## Integration checklist
 
-1. Select native PWHOIS or the explicit Team Cymru provider based on the
-   required data source.
+1. Select native PWHOIS, Team Cymru, or RISwhois based on the required data
+   source and semantics.
 2. Inspect the chosen module version, lookup method, and response type.
 3. Set application-appropriate timeout, response-size, and rate-limit policy.
 4. Classify every returned error with `errors.Is`, and test cancellation,

--- a/pwhois_json_test.go
+++ b/pwhois_json_test.go
@@ -64,6 +64,19 @@ func TestPublicJSONRecordContracts(t *testing.T) {
 				"ip", "origin_asns", "prefix", "registry", "source",
 			},
 		},
+		{
+			name:  "RISWhoisObservation",
+			value: RISWhoisObservation{},
+			keys:  []string{"collector", "observed_at", "peer"},
+		},
+		{
+			name:  "RISWhoisRouteResult",
+			value: RISWhoisRouteResult{},
+			keys: []string{
+				"descriptions", "endpoint", "fetched_at", "first_observed", "last_observed",
+				"origin_asn", "prefix", "query", "ris_peer_count", "rpsl_attributes", "seen_at", "source",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/riswhois.go
+++ b/riswhois.go
@@ -1,0 +1,536 @@
+package pwhois
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultRISWhoisServer is the documented RIPE RIS routing-table query
+	// endpoint.
+	DefaultRISWhoisServer = "riswhois.ripe.net"
+	// DefaultRISWhoisPort is the documented TCP WHOIS service port.
+	DefaultRISWhoisPort = 43
+
+	// RISWhoisSource identifies RIPE RISwhois results in provenance and cache
+	// keys.
+	RISWhoisSource = "ripe-riswhois"
+	// RISWhoisProtocolVersion identifies the query protocol used in cache keys.
+	RISWhoisProtocolVersion = "riswhois-rpsl-v2"
+	// RISWhoisParserVersion identifies the parser contract used in cache keys.
+	RISWhoisParserVersion = "riswhois-rpsl-v1"
+	// RISWhoisResultSchemaVersion identifies the normalized result shape used
+	// in cache keys.
+	RISWhoisResultSchemaVersion = "riswhois-route-result-v1"
+)
+
+// RISWhoisProvider configures explicit observed-route lookups against RIPE
+// RISwhois. It is separate from WhoisServer because RISwhois queries collected
+// BGP routing tables and returns RPSL; it is not native PWHOIS or an IRR.
+type RISWhoisProvider struct {
+	Server  string
+	Port    int
+	Timeout time.Duration
+	// MaxResponseBytes bounds the complete provider response before parsing. A
+	// value less than or equal to zero uses DefaultMaxResponseBytes.
+	MaxResponseBytes int64
+	// Dialer optionally replaces the default TCP dialer. It must honor context
+	// cancellation and be safe for concurrent use when the provider is shared.
+	Dialer ContextDialer
+}
+
+// RISWhoisObservation records a timestamp supplied by RISwhois and the RIS
+// peer and route collector associated with that observation.
+type RISWhoisObservation struct {
+	ObservedAt time.Time `json:"observed_at"`
+	Peer       string    `json:"peer"`
+	Collector  string    `json:"collector"`
+}
+
+// RISWhoisRouteResult is source-specific evidence from the routing tables
+// collected by RIPE RIS. It describes observed BGP routing, not allocation,
+// ownership, geolocation, or published IRR policy.
+//
+// RPSLAttributes preserves every response attribute using normalized,
+// lower-case names and ordered values. Typed fields are derived from those
+// attributes for common use.
+type RISWhoisRouteResult struct {
+	Query          string              `json:"query"`
+	Prefix         string              `json:"prefix"`
+	OriginASN      uint32              `json:"origin_asn"`
+	Descriptions   []string            `json:"descriptions"`
+	FirstObserved  RISWhoisObservation `json:"first_observed"`
+	LastObserved   RISWhoisObservation `json:"last_observed"`
+	SeenAt         []string            `json:"seen_at"`
+	RISPeerCount   uint32              `json:"ris_peer_count"`
+	RPSLAttributes map[string][]string `json:"rpsl_attributes"`
+	Source         string              `json:"source"`
+	Endpoint       string              `json:"endpoint"`
+	FetchedAt      time.Time           `json:"fetched_at"`
+}
+
+type risWhoisQuery struct {
+	normalized string
+	wire       string
+	match      string
+	ip         net.IP
+	prefix     *net.IPNet
+}
+
+func (provider RISWhoisProvider) configured() RISWhoisProvider {
+	if provider.Server == "" {
+		provider.Server = DefaultRISWhoisServer
+	}
+	if provider.Port == 0 {
+		provider.Port = DefaultRISWhoisPort
+	}
+	if provider.Timeout <= 0 {
+		provider.Timeout = time.Second * time.Duration(SocketTimeout)
+	}
+	if provider.MaxResponseBytes <= 0 {
+		provider.MaxResponseBytes = DefaultMaxResponseBytes
+	}
+	return provider
+}
+
+// ServerAddressString returns the configured RISwhois TCP endpoint.
+func (provider RISWhoisProvider) ServerAddressString() string {
+	provider = provider.configured()
+	return net.JoinHostPort(provider.Server, strconv.Itoa(provider.Port))
+}
+
+func (provider RISWhoisProvider) operationError(operation string, err error) error {
+	return &OperationError{
+		Operation: operation,
+		Server:    provider.ServerAddressString(),
+		Err:       err,
+	}
+}
+
+func (provider RISWhoisProvider) dial(ctx context.Context) (net.Conn, error) {
+	if provider.Dialer != nil {
+		return provider.Dialer.DialContext(ctx, "tcp", provider.ServerAddressString())
+	}
+
+	dialer := &net.Dialer{
+		KeepAlive: time.Second * time.Duration(SocketKeepAlive),
+	}
+	return dialer.DialContext(ctx, "tcp", provider.ServerAddressString())
+}
+
+func normalizeRISWhoisQuery(value string) (risWhoisQuery, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return risWhoisQuery{}, invalidInputError("an IP address or prefix is required")
+	}
+
+	if ip := net.ParseIP(value); ip != nil {
+		canonical := ip.String()
+		return risWhoisQuery{
+			normalized: canonical,
+			wire:       "-M " + canonical + "\n",
+			match:      "longest",
+			ip:         ip,
+		}, nil
+	}
+
+	ip, prefix, err := net.ParseCIDR(value)
+	if err != nil {
+		return risWhoisQuery{}, invalidInputError("query must be an IP address or CIDR prefix")
+	}
+	if !prefix.IP.Equal(ip) {
+		return risWhoisQuery{}, invalidInputError("CIDR query must use its network address")
+	}
+
+	canonical := prefix.String()
+	return risWhoisQuery{
+		normalized: canonical,
+		wire:       "-x " + canonical + "\n",
+		match:      "exact",
+		prefix:     prefix,
+	}, nil
+}
+
+// CacheKeySpec returns the source-aware key specification for a RISwhois
+// lookup. It does not read or write a cache; the calling application still
+// selects an explicit CacheCoordinator policy.
+func (provider RISWhoisProvider) CacheKeySpec(value string) (CacheKeySpec, error) {
+	provider = provider.configured()
+	query, err := normalizeRISWhoisQuery(value)
+	if err != nil {
+		return CacheKeySpec{}, err
+	}
+
+	return CacheKeySpec{
+		Source:              RISWhoisSource,
+		Endpoint:            provider.ServerAddressString(),
+		Protocol:            RISWhoisProtocolVersion,
+		NormalizedQuery:     query.normalized,
+		Options:             map[string]string{"match": query.match, "format": "rpsl"},
+		ParserVersion:       RISWhoisParserVersion,
+		ResultSchemaVersion: RISWhoisResultSchemaVersion,
+	}, nil
+}
+
+// LookupRouteContext returns every RISwhois route-origin object matching one
+// IP address or prefix. IP addresses request all longest-match origins;
+// prefixes request exact matches. Multiple-origin results remain separate.
+//
+// The call owns its connection, honors the shorter of the context deadline
+// and Timeout, applies MaxResponseBytes, and never retries or falls back to
+// another provider. A provider may be shared by concurrent callers when its
+// fields and custom Dialer are not mutated during use.
+func (provider RISWhoisProvider) LookupRouteContext(ctx context.Context, value string) ([]RISWhoisRouteResult, error) {
+	const operation = "lookup RISwhois observed route"
+
+	provider = provider.configured()
+	if ctx == nil {
+		return nil, provider.operationError(operation, invalidInputError("context must not be nil"))
+	}
+	query, err := normalizeRISWhoisQuery(value)
+	if err != nil {
+		return nil, provider.operationError(operation, err)
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, provider.Timeout)
+	defer cancel()
+
+	connection, err := provider.dial(lookupCtx)
+	if err != nil {
+		return nil, provider.operationError(operation, classifyContextTransportError(lookupCtx, err))
+	}
+	if connection == nil {
+		return nil, provider.operationError(operation, ErrConnection)
+	}
+	defer connection.Close()
+
+	stopCancellationClose := context.AfterFunc(lookupCtx, func() {
+		_ = connection.Close()
+	})
+	defer stopCancellationClose()
+
+	deadline, _ := lookupCtx.Deadline()
+	if err := connection.SetDeadline(deadline); err != nil {
+		return nil, provider.operationError(operation, classifyContextTransportError(lookupCtx, err))
+	}
+	written, err := io.WriteString(connection, query.wire)
+	if err == nil && written != len(query.wire) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		return nil, provider.operationError(operation, classifyContextTransportError(lookupCtx, err))
+	}
+
+	rawResponse, err := readBoundedResponse(connection, provider.MaxResponseBytes)
+	if err != nil {
+		if errors.Is(err, ErrResponseTooLarge) {
+			return nil, provider.operationError(operation, err)
+		}
+		return nil, provider.operationError(operation, classifyContextTransportError(lookupCtx, err))
+	}
+	if err := lookupCtx.Err(); err != nil {
+		return nil, provider.operationError(operation, classifyTransportError(err))
+	}
+
+	response := string(rawResponse)
+	switch {
+	case isRISWhoisRateLimitedResponse(response):
+		return nil, provider.operationError(operation, ErrRateLimited)
+	case isRISWhoisRejectedResponse(response):
+		return nil, provider.operationError(operation, ErrProviderRejected)
+	}
+
+	results, err := parseRISWhoisResponse(query, response, provider.ServerAddressString(), time.Now().UTC())
+	if err != nil {
+		return nil, provider.operationError(operation, err)
+	}
+	if err := lookupCtx.Err(); err != nil {
+		return nil, provider.operationError(operation, classifyTransportError(err))
+	}
+	return results, nil
+}
+
+func isRISWhoisRateLimitedResponse(response string) bool {
+	for _, line := range strings.Split(response, "\n") {
+		message, ok := risWhoisDiagnostic(line)
+		if ok && (strings.Contains(message, "rate limit") ||
+			strings.Contains(message, "query limit") ||
+			strings.Contains(message, "too many queries")) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRISWhoisRejectedResponse(response string) bool {
+	for _, line := range strings.Split(response, "\n") {
+		message, ok := risWhoisDiagnostic(line)
+		if !ok || strings.Contains(message, "no entries found") ||
+			strings.Contains(message, "no records found") {
+			continue
+		}
+		if strings.Contains(message, "error:") ||
+			strings.Contains(message, "access denied") ||
+			strings.Contains(message, "invalid query") {
+			return true
+		}
+	}
+	return false
+}
+
+func risWhoisDiagnostic(line string) (string, bool) {
+	trimmed := strings.ToLower(strings.TrimSpace(line))
+	if !strings.HasPrefix(trimmed, "%") {
+		return "", false
+	}
+	return strings.TrimSpace(strings.TrimLeft(trimmed, "%")), true
+}
+
+func parseRISWhoisResponse(query risWhoisQuery, response, endpoint string, fetchedAt time.Time) ([]RISWhoisRouteResult, error) {
+	if strings.TrimSpace(response) == "" {
+		return nil, noRecordsError("RISwhois observed-route lookup")
+	}
+
+	objects, err := parseRISWhoisRPSL(response)
+	if err != nil {
+		return nil, malformedResponseError(err)
+	}
+	if len(objects) == 0 {
+		return nil, noRecordsError("RISwhois observed-route lookup")
+	}
+
+	results := make([]RISWhoisRouteResult, 0, len(objects))
+	seen := make(map[string]struct{}, len(objects))
+	for index, attributes := range objects {
+		result, err := normalizeRISWhoisRoute(query, attributes, endpoint, fetchedAt)
+		if err != nil {
+			return nil, malformedResponseError(fmt.Errorf("normalize RISwhois object %d: %w", index+1, err))
+		}
+		key := fmt.Sprintf("%s|%d", result.Prefix, result.OriginASN)
+		if _, found := seen[key]; found {
+			return nil, malformedResponseError(fmt.Errorf("RISwhois object %d duplicates an earlier route origin", index+1))
+		}
+		seen[key] = struct{}{}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func parseRISWhoisRPSL(response string) ([]map[string][]string, error) {
+	objects := make([]map[string][]string, 0)
+	current := make(map[string][]string)
+	lastAttribute := ""
+
+	finishObject := func() {
+		if len(current) != 0 {
+			objects = append(objects, current)
+			current = make(map[string][]string)
+		}
+		lastAttribute = ""
+	}
+
+	for lineNumber, line := range strings.Split(response, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			finishObject()
+			continue
+		}
+		if strings.HasPrefix(trimmed, "%") {
+			continue
+		}
+
+		if (strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")) && lastAttribute != "" {
+			values := current[lastAttribute]
+			values[len(values)-1] += "\n" + trimmed
+			current[lastAttribute] = values
+			continue
+		}
+
+		colon := strings.IndexByte(line, ':')
+		if colon < 1 {
+			return nil, fmt.Errorf("parse RISwhois response line %d: expected RPSL attribute", lineNumber+1)
+		}
+
+		name := strings.ToLower(strings.TrimSpace(line[:colon]))
+		if !validRISWhoisAttributeName(name) {
+			return nil, fmt.Errorf("parse RISwhois response line %d: invalid RPSL attribute name", lineNumber+1)
+		}
+		value := strings.TrimSpace(line[colon+1:])
+		current[name] = append(current[name], value)
+		lastAttribute = name
+	}
+	finishObject()
+	return objects, nil
+}
+
+func validRISWhoisAttributeName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, character := range value {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= '0' && character <= '9') ||
+			character == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func normalizeRISWhoisRoute(query risWhoisQuery, attributes map[string][]string, endpoint string, fetchedAt time.Time) (RISWhoisRouteResult, error) {
+	routeValues := attributes["route"]
+	route6Values := attributes["route6"]
+	if len(routeValues)+len(route6Values) != 1 {
+		return RISWhoisRouteResult{}, fmt.Errorf("expected exactly one route or route6 attribute")
+	}
+
+	routeAttribute := "route"
+	prefixValue := ""
+	if len(routeValues) == 1 {
+		prefixValue = routeValues[0]
+	} else {
+		routeAttribute = "route6"
+		prefixValue = route6Values[0]
+	}
+	_, prefix, err := net.ParseCIDR(prefixValue)
+	if err != nil {
+		return RISWhoisRouteResult{}, fmt.Errorf("invalid %s prefix", routeAttribute)
+	}
+	if (routeAttribute == "route") != (prefix.IP.To4() != nil) {
+		return RISWhoisRouteResult{}, fmt.Errorf("%s attribute has the wrong address family", routeAttribute)
+	}
+	if query.ip != nil && !prefix.Contains(query.ip) {
+		return RISWhoisRouteResult{}, fmt.Errorf("route does not contain the queried IP")
+	}
+	if query.prefix != nil && prefix.String() != query.prefix.String() {
+		return RISWhoisRouteResult{}, fmt.Errorf("route is not an exact match for the queried prefix")
+	}
+
+	originValues := attributes["origin"]
+	if len(originValues) != 1 {
+		return RISWhoisRouteResult{}, fmt.Errorf("expected exactly one origin attribute")
+	}
+	originText := strings.TrimSpace(originValues[0])
+	if len(originText) < 3 || !strings.EqualFold(originText[:2], "AS") {
+		return RISWhoisRouteResult{}, fmt.Errorf("invalid origin ASN")
+	}
+	origin, err := strconv.ParseUint(originText[2:], 10, 32)
+	if err != nil {
+		return RISWhoisRouteResult{}, fmt.Errorf("invalid origin ASN")
+	}
+
+	sourceValues := attributes["source"]
+	if len(sourceValues) != 1 || !strings.EqualFold(strings.TrimSpace(sourceValues[0]), "RISWHOIS") {
+		return RISWhoisRouteResult{}, fmt.Errorf("expected source RISWHOIS")
+	}
+
+	firstObserved, err := parseRISWhoisOptionalObservation(attributes["lastupd-frst"], "lastupd-frst")
+	if err != nil {
+		return RISWhoisRouteResult{}, err
+	}
+	lastObserved, err := parseRISWhoisOptionalObservation(attributes["lastupd-last"], "lastupd-last")
+	if err != nil {
+		return RISWhoisRouteResult{}, err
+	}
+
+	seenAt, err := parseRISWhoisSeenAt(attributes["seen-at"])
+	if err != nil {
+		return RISWhoisRouteResult{}, err
+	}
+	peerCount, err := parseRISWhoisOptionalUint32(attributes["num-rispeers"], "num-rispeers")
+	if err != nil {
+		return RISWhoisRouteResult{}, err
+	}
+
+	return RISWhoisRouteResult{
+		Query:          query.normalized,
+		Prefix:         prefix.String(),
+		OriginASN:      uint32(origin),
+		Descriptions:   append([]string(nil), attributes["descr"]...),
+		FirstObserved:  firstObserved,
+		LastObserved:   lastObserved,
+		SeenAt:         seenAt,
+		RISPeerCount:   peerCount,
+		RPSLAttributes: copyRISWhoisAttributes(attributes),
+		Source:         RISWhoisSource,
+		Endpoint:       endpoint,
+		FetchedAt:      fetchedAt,
+	}, nil
+}
+
+func parseRISWhoisOptionalObservation(values []string, field string) (RISWhoisObservation, error) {
+	if len(values) == 0 {
+		return RISWhoisObservation{}, nil
+	}
+	if len(values) != 1 {
+		return RISWhoisObservation{}, fmt.Errorf("expected at most one %s attribute", field)
+	}
+
+	parts := strings.Fields(values[0])
+	if len(parts) != 3 {
+		return RISWhoisObservation{}, fmt.Errorf("invalid %s observation", field)
+	}
+	observedAt, err := time.Parse("2006-01-02 15:04Z", parts[0]+" "+parts[1])
+	if err != nil {
+		return RISWhoisObservation{}, fmt.Errorf("invalid %s timestamp", field)
+	}
+
+	at := strings.LastIndexByte(parts[2], '@')
+	if at < 1 || at == len(parts[2])-1 {
+		return RISWhoisObservation{}, fmt.Errorf("invalid %s peer and collector", field)
+	}
+	peer := parts[2][:at]
+	collector := parts[2][at+1:]
+	if net.ParseIP(peer) == nil || strings.ContainsAny(collector, " \t,\r\n") {
+		return RISWhoisObservation{}, fmt.Errorf("invalid %s peer and collector", field)
+	}
+
+	return RISWhoisObservation{
+		ObservedAt: observedAt,
+		Peer:       peer,
+		Collector:  collector,
+	}, nil
+}
+
+func parseRISWhoisSeenAt(values []string) ([]string, error) {
+	var collectors []string
+	for _, value := range values {
+		for _, collector := range strings.Split(value, ",") {
+			collector = strings.TrimSpace(collector)
+			if collector == "" || strings.ContainsAny(collector, " \t\r\n") {
+				return nil, fmt.Errorf("invalid seen-at collector")
+			}
+			collectors = append(collectors, collector)
+		}
+	}
+	return collectors, nil
+}
+
+func parseRISWhoisOptionalUint32(values []string, field string) (uint32, error) {
+	if len(values) == 0 {
+		return 0, nil
+	}
+	if len(values) != 1 {
+		return 0, fmt.Errorf("expected at most one %s attribute", field)
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(values[0]), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s value", field)
+	}
+	return uint32(value), nil
+}
+
+func copyRISWhoisAttributes(attributes map[string][]string) map[string][]string {
+	copied := make(map[string][]string, len(attributes))
+	for name, values := range attributes {
+		copied[name] = append([]string(nil), values...)
+	}
+	return copied
+}

--- a/riswhois.go
+++ b/riswhois.go
@@ -134,9 +134,12 @@ func normalizeRISWhoisQuery(value string) (risWhoisQuery, error) {
 		canonical := ip.String()
 		return risWhoisQuery{
 			normalized: canonical,
-			wire:       "-M " + canonical + "\n",
-			match:      "longest",
-			ip:         ip,
+			// RISwhois gives -M an IP-specific meaning: return only the
+			// longest matches. For prefix inputs, -M instead means all more
+			// specifics; those use -x below.
+			wire:  "-M " + canonical + "\n",
+			match: "longest",
+			ip:    ip,
 		}, nil
 	}
 

--- a/riswhois_test.go
+++ b/riswhois_test.go
@@ -1,0 +1,372 @@
+package pwhois
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+const (
+	risWhoisIPRequest     = "-M 192.0.2.1\n"
+	risWhoisPrefixRequest = "-x 198.51.100.0/24\n"
+	risWhoisRouteResult   = `route:        192.0.2.0/24
+origin:       AS64500
+descr:        EXAMPLE-AS - Example Network, ZZ
+lastupd-frst: 2026-07-01 12:34Z  198.51.100.10@rrc00
+lastupd-last: 2026-07-29 15:45Z  2001:db8::10@rrc25
+seen-at:      rrc00,rrc25
+num-rispeers: 42
+source:       RISWHOIS`
+)
+
+func loopbackRISWhoisProvider(t *testing.T, script loopbackProtocolScript) (RISWhoisProvider, <-chan loopbackProtocolResult) {
+	t.Helper()
+
+	server, results := startLoopbackProtocolServer(t, script)
+	return RISWhoisProvider{
+		Server:           server.Server,
+		Port:             server.Port,
+		Timeout:          server.Timeout,
+		MaxResponseBytes: server.MaxResponseBytes,
+	}, results
+}
+
+func TestRISWhoisIPAndPrefixLookups(t *testing.T) {
+	tests := []struct {
+		name            string
+		query           string
+		expectedRequest string
+		response        string
+		expectedPrefix  string
+		expectedASN     uint32
+	}{
+		{
+			name:            "IPv4 address requests longest match",
+			query:           " 192.0.2.1 ",
+			expectedRequest: risWhoisIPRequest,
+			response:        "% synthetic banner\n\n" + risWhoisRouteResult,
+			expectedPrefix:  "192.0.2.0/24",
+			expectedASN:     64500,
+		},
+		{
+			name:            "prefix requests exact match",
+			query:           "198.51.100.0/24",
+			expectedRequest: risWhoisPrefixRequest,
+			response: `route:        198.51.100.0/24
+origin:       AS64501
+source:       RISWHOIS`,
+			expectedPrefix: "198.51.100.0/24",
+			expectedASN:    64501,
+		},
+		{
+			name:            "IPv6 address requests longest match",
+			query:           "2001:db8::1",
+			expectedRequest: "-M 2001:db8::1\n",
+			response: `route6:       2001:db8::/32
+origin:       AS64502
+seen-at:      rrc01
+source:       RISWHOIS`,
+			expectedPrefix: "2001:db8::/32",
+			expectedASN:    64502,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider, protocolResult := loopbackRISWhoisProvider(t, loopbackProtocolScript{
+				expectedRequest: test.expectedRequest,
+				responseChunks:  []string{test.response},
+			})
+			started := time.Now().UTC()
+
+			results, err := provider.LookupRouteContext(context.Background(), test.query)
+			if err != nil {
+				t.Fatalf("LookupRouteContext: %v", err)
+			}
+			finished := time.Now().UTC()
+			if len(results) != 1 {
+				t.Fatalf("results = %+v", results)
+			}
+			result := results[0]
+			if result.Prefix != test.expectedPrefix || result.OriginASN != test.expectedASN {
+				t.Fatalf("route result = %+v", result)
+			}
+			if result.Source != RISWhoisSource || result.Endpoint != provider.ServerAddressString() {
+				t.Fatalf("provenance = %+v", result)
+			}
+			if result.FetchedAt.Before(started) || result.FetchedAt.After(finished) {
+				t.Fatalf("fetched at = %v, want between %v and %v", result.FetchedAt, started, finished)
+			}
+			verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, test.expectedRequest)
+		})
+	}
+}
+
+func TestParseRISWhoisTypedAndRepeatedAttributes(t *testing.T) {
+	query, err := normalizeRISWhoisQuery("192.0.2.1")
+	if err != nil {
+		t.Fatalf("normalize query: %v", err)
+	}
+	fetchedAt := time.Date(2026, 7, 29, 20, 0, 0, 0, time.UTC)
+	response := `% comment before object
+route: 192.0.2.0/24
+origin: AS64500
+descr: first description
+descr: second description
+remarks: first line
+ continuation: line
+seen-at: rrc00
+seen-at: rrc01, rrc02
+lastupd-frst: 2026-07-01 12:34Z  198.51.100.10@rrc00
+lastupd-last: 2026-07-29 15:45Z  2001:db8::10@rrc25
+num-rispeers: 42
+source: RISWHOIS
+
+route: 192.0.2.0/24
+origin: AS64501
+descr: alternate origin
+source: RISWHOIS`
+
+	results, err := parseRISWhoisResponse(query, response, "ris.example:43", fetchedAt)
+	if err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %+v", results)
+	}
+
+	first := results[0]
+	if !reflect.DeepEqual(first.Descriptions, []string{"first description", "second description"}) {
+		t.Fatalf("descriptions = %v", first.Descriptions)
+	}
+	if !reflect.DeepEqual(first.SeenAt, []string{"rrc00", "rrc01", "rrc02"}) {
+		t.Fatalf("seen at = %v", first.SeenAt)
+	}
+	if first.RISPeerCount != 42 {
+		t.Fatalf("RIS peer count = %d", first.RISPeerCount)
+	}
+	if first.FirstObserved.Peer != "198.51.100.10" || first.FirstObserved.Collector != "rrc00" ||
+		!first.FirstObserved.ObservedAt.Equal(time.Date(2026, 7, 1, 12, 34, 0, 0, time.UTC)) {
+		t.Fatalf("first observation = %+v", first.FirstObserved)
+	}
+	if first.LastObserved.Peer != "2001:db8::10" || first.LastObserved.Collector != "rrc25" {
+		t.Fatalf("last observation = %+v", first.LastObserved)
+	}
+	if got := first.RPSLAttributes["remarks"]; !reflect.DeepEqual(got, []string{"first line\ncontinuation: line"}) {
+		t.Fatalf("continued RPSL attribute = %q", got)
+	}
+	if results[1].OriginASN != 64501 || results[1].Prefix != first.Prefix {
+		t.Fatalf("multiple origin result = %+v", results[1])
+	}
+}
+
+func TestParseRISWhoisResponseFailures(t *testing.T) {
+	ipQuery, err := normalizeRISWhoisQuery("192.0.2.1")
+	if err != nil {
+		t.Fatalf("normalize IP query: %v", err)
+	}
+	prefixQuery, err := normalizeRISWhoisQuery("192.0.2.0/24")
+	if err != nil {
+		t.Fatalf("normalize prefix query: %v", err)
+	}
+	fetchedAt := time.Date(2026, 7, 29, 20, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		query     risWhoisQuery
+		response  string
+		wantError error
+	}{
+		{name: "empty", query: ipQuery, response: "", wantError: ErrNoRecords},
+		{name: "comments only", query: ipQuery, response: "% no entries found\n", wantError: ErrNoRecords},
+		{
+			name:      "malformed line",
+			query:     ipQuery,
+			response:  "not an RPSL attribute",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "missing route",
+			query:     ipQuery,
+			response:  "origin: AS64500\nsource: RISWHOIS",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "both route families",
+			query:     ipQuery,
+			response:  "route: 192.0.2.0/24\nroute6: 2001:db8::/32\norigin: AS64500\nsource: RISWHOIS",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "route field has wrong family",
+			query:     ipQuery,
+			response:  "route: 2001:db8::/32\norigin: AS64500\nsource: RISWHOIS",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "route does not contain IP",
+			query:     ipQuery,
+			response:  "route: 198.51.100.0/24\norigin: AS64500\nsource: RISWHOIS",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "prefix response is not exact",
+			query:     prefixQuery,
+			response:  "route: 192.0.0.0/16\norigin: AS64500\nsource: RISWHOIS",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "invalid origin",
+			query:     ipQuery,
+			response:  "route: 192.0.2.0/24\norigin: not-an-asn\nsource: RISWHOIS",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "missing source",
+			query:     ipQuery,
+			response:  "route: 192.0.2.0/24\norigin: AS64500",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "wrong source",
+			query:     ipQuery,
+			response:  "route: 192.0.2.0/24\norigin: AS64500\nsource: TEST",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "invalid observation",
+			query:     ipQuery,
+			response:  "route: 192.0.2.0/24\norigin: AS64500\nlastupd-last: yesterday\nsource: RISWHOIS",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "invalid peer count",
+			query:     ipQuery,
+			response:  "route: 192.0.2.0/24\norigin: AS64500\nnum-rispeers: many\nsource: RISWHOIS",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:  "duplicate route origin",
+			query: ipQuery,
+			response: "route: 192.0.2.0/24\norigin: AS64500\nsource: RISWHOIS\n\n" +
+				"route: 192.0.2.0/24\norigin: AS64500\nsource: RISWHOIS",
+			wantError: ErrMalformedResponse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseRISWhoisResponse(test.query, test.response, "ris.example:43", fetchedAt)
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("parse error = %v, want %v", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestRISWhoisProviderErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  string
+		wantError error
+	}{
+		{
+			name:      "rate limited diagnostic",
+			response:  "%ERROR: query rate limit exceeded",
+			wantError: ErrRateLimited,
+		},
+		{
+			name:      "provider rejection",
+			response:  "%ERROR: invalid query",
+			wantError: ErrProviderRejected,
+		},
+		{
+			name:      "diagnostic phrase in data is not rate limit",
+			response:  risWhoisRouteResult + "\nremarks: rate limit documentation",
+			wantError: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider, protocolResult := loopbackRISWhoisProvider(t, loopbackProtocolScript{
+				expectedRequest: risWhoisIPRequest,
+				responseChunks:  []string{test.response},
+			})
+			_, err := provider.LookupRouteContext(context.Background(), "192.0.2.1")
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("lookup error = %v, want %v", err, test.wantError)
+			}
+			verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, risWhoisIPRequest)
+		})
+	}
+}
+
+func TestRISWhoisInputAndCacheKey(t *testing.T) {
+	provider := RISWhoisProvider{}
+	for _, value := range []string{"", "not-an-ip", "192.0.2.1/24"} {
+		if _, err := provider.LookupRouteContext(context.Background(), value); !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("query %q error = %v, want ErrInvalidInput", value, err)
+		}
+	}
+	if _, err := provider.LookupRouteContext(nil, "192.0.2.1"); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("nil context error = %v, want ErrInvalidInput", err)
+	}
+
+	ipSpec, err := provider.CacheKeySpec(" 192.0.2.1 ")
+	if err != nil {
+		t.Fatalf("IP CacheKeySpec: %v", err)
+	}
+	prefixSpec, err := provider.CacheKeySpec("198.51.100.0/24")
+	if err != nil {
+		t.Fatalf("prefix CacheKeySpec: %v", err)
+	}
+	if ipSpec.Source != RISWhoisSource || ipSpec.Endpoint != "riswhois.ripe.net:43" ||
+		ipSpec.NormalizedQuery != "192.0.2.1" || ipSpec.Options["match"] != "longest" {
+		t.Fatalf("IP cache key spec = %+v", ipSpec)
+	}
+	if prefixSpec.NormalizedQuery != "198.51.100.0/24" || prefixSpec.Options["match"] != "exact" {
+		t.Fatalf("prefix cache key spec = %+v", prefixSpec)
+	}
+	ipKey, err := CanonicalCacheKey(ipSpec)
+	if err != nil {
+		t.Fatalf("canonical IP key: %v", err)
+	}
+	prefixKey, err := CanonicalCacheKey(prefixSpec)
+	if err != nil {
+		t.Fatalf("canonical prefix key: %v", err)
+	}
+	if ipKey == prefixKey {
+		t.Fatalf("IP and prefix cache keys must differ: %q", ipKey)
+	}
+}
+
+func TestRISWhoisResponseLimit(t *testing.T) {
+	provider, protocolResult := loopbackRISWhoisProvider(t, loopbackProtocolScript{
+		expectedRequest: risWhoisIPRequest,
+		responseChunks:  []string{risWhoisRouteResult},
+	})
+	provider.MaxResponseBytes = 16
+
+	_, err := provider.LookupRouteContext(context.Background(), "192.0.2.1")
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("lookup error = %v, want ErrResponseTooLarge", err)
+	}
+	verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, risWhoisIPRequest)
+}
+
+func TestRISWhoisContextDeadline(t *testing.T) {
+	provider, protocolResult := loopbackRISWhoisProvider(t, loopbackProtocolScript{
+		expectedRequest: risWhoisIPRequest,
+		noResponse:      true,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := provider.LookupRouteContext(ctx, "192.0.2.1")
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("lookup error = %v, want ErrTimeout", err)
+	}
+	verifyAutomaticallyClosedLoopbackProtocol(t, protocolResult, risWhoisIPRequest)
+}


### PR DESCRIPTION
## Summary

- add an explicit context-aware `RISWhoisProvider` for longest-match IP and exact-match prefix queries
- normalize observed route/origin, collector visibility, RIS peer count, provider observations, fetch provenance, and ordered RPSL attributes
- reject malformed, unrelated, duplicate, oversized, rate-limited, and provider-rejected responses without exposing raw response content
- add source/match/parser/schema-aware cache keys and short-lived RISwhois cache-policy guidance
- document that RISwhois is observed BGP evidence, not PWHOIS, registration, geolocation, or published IRR policy

## Validation

- `go test ./...`
- `go test -run RISWhois -count=20 ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go mod tidy`
- `go mod verify`
- `git diff --check`

All required protocol coverage uses synthetic/reserved data and a scripted IPv4 loopback server. No public RISwhois request is part of required CI.

## Release impact

This adds exported provider/result types and JSON contracts without changing the existing native PWHOIS or Team Cymru APIs.

Closes #52
Closes #14