### PR TITLE
Add referral-aware RDAP registration provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,11 @@ another application must start with
 
 - `pwhois` supports native PWHOIS IP, RouteView, registry, and netblock queries
   plus the explicit `TeamCymruProvider` IP-to-ASN and `RISWhoisProvider`
-  observed-route protocols. It is not a generic WHOIS, IRR, or RDAP client.
-  Changing only `WhoisServer.Server` or a provider hostname does not establish
-  compatibility with another response format; add a source-specific
-  implementation and tests first.
+  observed-route protocols and the `RDAPProvider` IP/ASN registration
+  protocol. It is not a generic WHOIS or IRR client. Changing only
+  `WhoisServer.Server` or a provider hostname does not establish compatibility
+  with another response format; add a source-specific implementation and tests
+  first.
 - The exported Go API, JSON field names, README, and deterministic tests are
   consumer-facing contracts. Keep them aligned when behavior changes. Preserve
   the serialization conventions corrected in #22 and #25 deliberately; use
@@ -46,6 +47,10 @@ another application must start with
 - `RISWhoisProvider` is always explicit, uses longest-match IP or exact-match
   prefix queries, and never falls back. Its output is observed BGP evidence
   from RIPE RIS collectors, not RIR registration, geolocation, or IRR policy.
+- `RDAPProvider` uses cached IANA bootstrap registries and bounded
+  bootstrap-authorized HTTPS referrals. Normalized results omit complete
+  jCards, personal names, contact details, addresses, event actors, raw JSON,
+  and redaction paths. Do not weaken those privacy or referral boundaries.
 - Respect server rate limits. Rate-limit responses and network errors are
   normal caller-visible outcomes, not conditions to hide with automatic retry.
 
@@ -55,8 +60,8 @@ another application must start with
   pull request. Use `go test -race ./...` when changing concurrency or network
   behavior.
 - Default tests must be deterministic and must not contact public PWHOIS, Team
-  Cymru, RISwhois, or other provider servers. Native PWHOIS live checks are opt-in:
-  `go test -tags=integration ./...`.
+  Cymru, RISwhois, IANA bootstrap, RDAP, or other provider servers. Native
+  PWHOIS live checks are opt-in: `go test -tags=integration ./...`.
 - Use reserved and synthetic addresses, ASNs, organizations, and response data
   in tests and documentation. Never commit live/private registry responses,
   contact data, credentials, local paths, or rate-limit artifacts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ Thanks for improving `pwhois`.
 
 `pwhois` is a Go client and parser for native PWHOIS IP, RouteView, registry,
 and netblock queries plus explicit source-specific providers such as Team
-Cymru IP-to-ASN mapping and RIPE RISwhois observed routes. It is not a generic
-WHOIS, IRR, or RDAP client. Keep network policy, retries, logging, storage,
-scheduling, and application actions in the consuming application.
+Cymru IP-to-ASN mapping, RIPE RISwhois observed routes, and RDAP registration.
+It is not a generic WHOIS or IRR client. Keep network policy, retries, logging,
+storage, scheduling, and application actions in the consuming application.
 
 ## Before opening a pull request
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 server and parsing its IP, routing, registry, and netblock responses. It also
 provides explicit, source-specific clients for
 [Team Cymru IP-to-ASN mapping](https://www.team-cymru.com/ip-asn-mapping) and
-[RIPE RISwhois observed BGP routes](https://ris.ripe.net/docs/ris-whois/).
+[RIPE RISwhois observed BGP routes](https://ris.ripe.net/docs/ris-whois/), plus
+standards-based [RDAP registration data](https://www.rfc-editor.org/rfc/rfc9224.html).
 
 Created by George Starcher. The implementation references the original [`whob` source code](https://github.com/irr/whob/blob/master/whob).
 
@@ -19,6 +20,7 @@ Created by George Starcher. The implementation references the original [`whob` s
 - Netblocks announced by an ASN
 - Team Cymru IP-to-origin-ASN and prefix enrichment
 - RIPE RISwhois observed prefix, origin ASN, and collector evidence
+- RDAP IP allocation/assignment and ASN registration context
 
 ## Install
 
@@ -153,6 +155,8 @@ maintainers should use the [maintainer guide](AGENTS.md).
 | Netblock | `LookupNetblockContext` | `NetblockRecord` |
 | Team Cymru IP-to-ASN | `TeamCymruProvider.LookupIPContext` | `[]TeamCymruIPResult` |
 | RISwhois observed route | `RISWhoisProvider.LookupRouteContext` | `[]RISWhoisRouteResult` |
+| RDAP IP registration | `RDAPProvider.LookupIPContext` | `RDAPIPResult` |
+| RDAP ASN registration | `RDAPProvider.LookupASNContext` | `RDAPASNResult` |
 
 ## Team Cymru IP-to-ASN provider
 
@@ -235,18 +239,73 @@ Port 43 traffic is plaintext. Do not send an address or prefix to this
 third-party provider unless the calling application's privacy and data-handling
 policy allows it.
 
+## RDAP registration provider
+
+`RDAPProvider` performs HTTPS/JSON registration lookups for one IP address or
+ASN. It resolves the authoritative service through the
+[IANA RDAP bootstrap registries defined by RFC 9224](https://www.rfc-editor.org/rfc/rfc9224.html),
+caches those bootstrap documents using their HTTP expiry, and follows
+transfers/referrals manually. The final registration range must contain the
+query.
+
+```go
+provider := pwhois.RDAPProvider{}
+registration, err := provider.LookupIPContext(
+	context.Background(),
+	"192.0.2.1",
+)
+
+asnRegistration, err := provider.LookupASNContext(
+	context.Background(),
+	"AS64500",
+)
+```
+
+The zero value uses a shared cached IANA bootstrap resolver, the default HTTP
+client, a five-second total deadline, an 8 MiB final-response limit, and at
+most three referrals. Both bootstrap and final responses enforce their
+documented JSON content type. Public bootstrap and RDAP URLs must use HTTPS.
+Use `NewRDAPProvider(client)` when a custom HTTP client must serve both
+bootstrap and authoritative requests with a provider-owned bootstrap cache.
+Cross-origin referrals are accepted only when their authority appears in the
+same trusted IANA bootstrap document, the requested IP or ASN is unchanged,
+and the bounded chain has no loop. `AllowInsecureHTTP` and
+`AllowPrivateNetworkTargets` exist only for controlled local test
+infrastructure and should not be enabled for public traffic.
+
+`RDAPIPResult` and `RDAPASNResult` contain allocation/range identifiers,
+status, provider events, public registered-organization values, abuse entity
+handles, redaction indicators, final registry provenance, and fetch time.
+They deliberately omit full jCards, personal names, email addresses, telephone
+numbers, postal addresses, event actors, raw JSON, and redaction JSON paths.
+This keeps normalized cached values privacy-minimized. It does not make public
+organization or entity handles non-sensitive; applications still control
+retention and display.
+
+HTTP 404 and 429 responses map to `ErrNoRecords` and `ErrRateLimited`.
+Applications must enforce source/registry-specific request rates and retry
+policy; the provider does not retry or fail over automatically.
+`RDAPProvider.IPCacheKeySpec` and `ASNCacheKeySpec` distinguish object type,
+bootstrap identity, referral bound, transport/target scope, privacy profile,
+parser, and result schema.
+A 24-hour success TTL, 15-minute no-record TTL, 1-minute rate-limit TTL, and
+24-hour maximum successful-stale window are a reasonable starting point for
+registration enrichment; applications needing current transfer information
+should shorten or bypass it.
+
 ## Providers and servers
 
 `SetDefaultValues` configures `whois.pwhois.org:43`. You can set `WhoisServer.Server` and `WhoisServer.Port` before calling `Connect`, but compatibility with alternative servers is not yet validated. Availability and rate limits are controlled by each server operator.
 
-`TeamCymruProvider` and `RISWhoisProvider` are separate protocol-specific
-providers. Generic WHOIS, IRR, and RDAP endpoints are not drop-in-compatible
-with these clients.
+`TeamCymruProvider`, `RISWhoisProvider`, and `RDAPProvider` are separate
+protocol-specific providers. Generic WHOIS and IRR endpoints are not
+drop-in-compatible with these clients, and arbitrary RDAP base URLs are not
+substitutes for the bootstrap/referral contract.
 
 ## Development
 
 The default checks are deterministic and do not contact public PWHOIS, Team
-Cymru, or RISwhois servers:
+Cymru, RISwhois, IANA bootstrap, or RDAP servers:
 
 ```shell
 go test ./...
@@ -273,12 +332,15 @@ The live tests depend on the public service's availability, response data, and r
 
 The explicit JSON-tagged data records (`WhoIs`, `BGPRoute`, `BGPRoutes`,
 `RegistryRecord`, `Registry`, `NetblockRecord`, `Netblock`, and
-`TeamCymruIPResult`, `RISWhoisObservation`, and `RISWhoisRouteResult`) use
-normalized snake_case keys and are covered by serialization tests. Postal
-codes are text so leading zeros and alphanumeric values are preserved.
+`TeamCymruIPResult`, `RISWhoisObservation`, `RISWhoisRouteResult`, `RDAPEvent`,
+`RDAPEntityReference`, `RDAPRedactionIndicator`, `RDAPIPResult`, and
+`RDAPASNResult`) use normalized snake_case keys and are covered by serialization
+tests. Postal codes are text so leading zeros and alphanumeric values are
+preserved.
 
-`WhoisServer`, `TeamCymruProvider`, `RISWhoisProvider`, and the channel response
-wrappers are connection/control types, not JSON output contracts.
+`WhoisServer`, `TeamCymruProvider`, `RISWhoisProvider`, `RDAPProvider`, bootstrap
+resolvers, and the channel response wrappers are connection/control types, not
+JSON output contracts.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,3 +22,12 @@ module bounds connection time, lookup I/O time, and response size, but
 applications remain responsible for their chosen provider, privacy policy,
 rate-limit policy, data retention, and how results are displayed or acted
 upon. Port 43 queries are plaintext.
+
+RDAP lookups require HTTPS by default and follow only bounded referrals whose
+authority appeared in the trusted bootstrap document. Normalized RDAP results
+omit complete jCards, personal names, email addresses, telephone numbers,
+postal addresses, event actors, raw JSON, and redaction paths. Do not enable
+the insecure-HTTP or private-network target options for public lookups. A
+custom HTTP transport or bootstrap resolver is part of the application's trust
+boundary and must not inject credentials or authorize arbitrary internal
+destinations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,9 @@ RDAP lookups require HTTPS by default and follow only bounded referrals whose
 authority appeared in the trusted bootstrap document. Normalized RDAP results
 omit complete jCards, personal names, email addresses, telephone numbers,
 postal addresses, event actors, raw JSON, and redaction paths. Do not enable
-the insecure-HTTP or private-network target options for public lookups. A
-custom HTTP transport or bootstrap resolver is part of the application's trust
-boundary and must not inject credentials or authorize arbitrary internal
-destinations.
+the insecure-HTTP or private-network target options for public lookups.
+Public-only mode also rejects DNS results in private, reserved, documentation,
+benchmarking, and other IANA special-purpose ranges at dial time, and bypasses
+HTTP proxies whose remote resolution could evade that check. A custom HTTP
+transport or bootstrap resolver is part of the application's trust boundary
+and must not inject credentials or authorize arbitrary internal destinations.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,8 +12,9 @@ synthetic reproduction.
 
 This project supports native PWHOIS IP, RouteView, registry, and netblock
 queries plus its documented source-specific providers. RISwhois support is
-observed BGP evidence and does not make this a generic IRR client. Generic
-WHOIS, IRR, and RDAP protocols are outside its current scope; changing only
+observed BGP evidence and does not make this a generic IRR client. RDAP support
+is limited to the documented IANA-bootstrap IP/ASN registration provider.
+Generic WHOIS and IRR protocols are outside its current scope; changing only
 the server hostname does not make them compatible.
 
 ## Sensitive data and security

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,10 +27,11 @@ are opt-in:
 go test -tags=integration ./...
 ```
 
-Required native PWHOIS, Team Cymru, and RISwhois protocol coverage uses only
-scripted IPv4 loopback servers or injected connections. It exercises real TCP
-connect, request, response, EOF, timeout, cancellation, response bounds, and
-connection cleanup without depending on a public service.
+Required native PWHOIS, Team Cymru, RISwhois, IANA-bootstrap, and RDAP protocol
+coverage uses only scripted IPv4 loopback servers, local HTTP servers, or
+injected connections. It exercises connect, request, response, redirect,
+timeout, cancellation, response bounds, and connection cleanup without
+depending on a public service.
 
 The repository does not yet have a canonical documentation-validation command;
 that work is tracked in issue #28.

--- a/docs/cache-contract.md
+++ b/docs/cache-contract.md
@@ -12,9 +12,9 @@ The cache API separates three responsibilities:
 This is cache infrastructure, not an implicit wrapper around the high-level
 provider clients. Applications may use the native PWHOIS context methods or
 `TeamCymruProvider.LookupIPContext` or
-`RISWhoisProvider.LookupRouteContext` inside their context-aware fetch
-operation, but they must still select a source, cache policy, and normalized
-result explicitly.
+`RISWhoisProvider.LookupRouteContext`, `RDAPProvider.LookupIPContext`, or
+`RDAPProvider.LookupASNContext` inside their context-aware fetch operation, but
+they must still select a source, cache policy, and normalized result explicitly.
 The deprecated channel-based lookup methods continue to require a caller-owned
 connection.
 
@@ -66,6 +66,14 @@ For operational enrichment, a 15-minute success TTL, 5-minute no-record TTL,
 1-minute rate-limit TTL, and 30-minute maximum successful-stale window are a
 reasonable starting point. Applications using routing changes for alerts or
 decisions should choose a shorter TTL or bypass caching explicitly.
+
+RDAP keys must use `RDAPProvider.IPCacheKeySpec` or `ASNCacheKeySpec` so IP and
+ASN objects, bootstrap identity, referral bounds, transport/target scope,
+privacy profile, parser, and schema cannot collide. The normalized RDAP result
+is intentionally privacy-minimized; cache backends must never replace it with
+raw RDAP JSON or full entity/jCard contact data. For registration enrichment,
+a 24-hour success TTL, 15-minute no-record TTL, 1-minute rate-limit TTL, and
+24-hour maximum successful-stale window are a reasonable starting point.
 
 ## Lookup policies
 

--- a/docs/consumer-agent-guide.md
+++ b/docs/consumer-agent-guide.md
@@ -26,7 +26,8 @@ Read the selected `go.mod` version and the project README. Do not copy future
 APIs from open issues or assume a generic WHOIS, IRR, or RDAP server accepts
 the PWHOIS query and response format. Team Cymru support uses the separate
 `TeamCymruProvider`, and RISwhois support uses `RISWhoisProvider`; neither is
-a `WhoisServer` endpoint.
+a `WhoisServer` endpoint. Registration lookups use `RDAPProvider` with IANA
+bootstrap discovery rather than a caller-selected legacy WHOIS hostname.
 
 ## Choose a lookup
 
@@ -52,6 +53,12 @@ and returns every matching `RISWhoisRouteResult`. IP queries request all
 longest-match origins; prefix queries request exact matches. These are
 observations from collected routing tables, not RIR registration, geolocation,
 or published IRR policy.
+
+For registration/allocation context, use `RDAPProvider.LookupIPContext` or
+`LookupASNContext`. These return privacy-minimized `RDAPIPResult` or
+`RDAPASNResult` values. They omit complete jCards, personal names, contact
+details, addresses, event actors, raw JSON, and redaction paths. Do not infer
+current routing or geolocation from RDAP registration data.
 
 ## Connection and error handling
 
@@ -89,6 +96,15 @@ fall back, or cache.
 Its zero value uses `riswhois.ripe.net:43`, a five-second timeout, and the
 shared 8 MiB response limit. It performs one query, preserves multiple origins,
 and does not automatically retry, fall back, or cache.
+
+`RDAPProvider` applies one deadline to bootstrap resolution and the final
+lookup. Its zero value uses the shared cached IANA bootstrap resolver, HTTPS,
+an 8 MiB final-response bound, and at most three manually followed referrals.
+Use `NewRDAPProvider(client)` when both bootstrap and authoritative requests
+must use a custom HTTP client with a provider-owned bootstrap cache.
+Cross-origin referrals must retain the same IP or ASN and target an authority
+listed in the trusted bootstrap document. Do not enable insecure HTTP or
+private-network targets outside controlled local tests.
 
 `WhoisServer.MaxResponseBytes` bounds response data before parsing. Its zero
 value uses `DefaultMaxResponseBytes` (8 MiB), which provides more than 16 KiB
@@ -134,6 +150,13 @@ for `RISWhoisSource`. A 15-minute success TTL, 5-minute no-record TTL,
 reasonable short-lived starting policy; callers needing current routing
 evidence should shorten or bypass it.
 
+`RDAPProvider.IPCacheKeySpec` and `ASNCacheKeySpec` include the bootstrap
+identity, object type, referral bound, transport/target scope, privacy profile,
+parser, and result schema. Configure a separate policy for `RDAPSource`. A
+24-hour success TTL, 15-minute no-record TTL, 1-minute rate-limit TTL, and
+24-hour maximum successful-stale window are a reasonable
+registration-enrichment starting point.
+
 If the application uses this cache contract, read the
 [cache contract guide](cache-contract.md). In particular, configure a policy
 for each source, version parser/result schemas in the key, inspect
@@ -145,9 +168,10 @@ response in `NormalizedResult`.
 `SetDefaultValues` configures `whois.pwhois.org:43`, the tested native PWHOIS
 default. `TeamCymruProvider` explicitly configures the separate Team Cymru
 protocol, and `RISWhoisProvider` explicitly configures RISwhois RPSL routing
-observations. A different hostname alone does not establish compatibility with
-a generic WHOIS or IRR service. Public providers control their availability
-and rate limits, and port 43 sends queries in plaintext.
+observations. `RDAPProvider` explicitly uses IANA bootstrap registries and
+bounded referral validation. A different hostname alone does not establish
+compatibility with a generic WHOIS or IRR service. Public providers control
+their availability and rate limits, and port 43 sends queries in plaintext.
 
 Keep credentials, private addresses, live registry responses, contact data,
 and rate-limit details out of source code, committed fixtures, and prompts. Use
@@ -157,8 +181,8 @@ policy permits it.
 
 ## Integration checklist
 
-1. Select native PWHOIS, Team Cymru, or RISwhois based on the required data
-   source and semantics.
+1. Select native PWHOIS, Team Cymru, RISwhois, or RDAP based on the required
+   data source and semantics.
 2. Inspect the chosen module version, lookup method, and response type.
 3. Set application-appropriate timeout, response-size, and rate-limit policy.
 4. Classify every returned error with `errors.Is`, and test cancellation,

--- a/pwhois_json_test.go
+++ b/pwhois_json_test.go
@@ -77,6 +77,41 @@ func TestPublicJSONRecordContracts(t *testing.T) {
 				"origin_asn", "prefix", "query", "ris_peer_count", "rpsl_attributes", "seen_at", "source",
 			},
 		},
+		{
+			name:  "RDAPEvent",
+			value: RDAPEvent{},
+			keys:  []string{"action", "date"},
+		},
+		{
+			name:  "RDAPEntityReference",
+			value: RDAPEntityReference{},
+			keys:  []string{"handle", "roles"},
+		},
+		{
+			name:  "RDAPRedactionIndicator",
+			value: RDAPRedactionIndicator{},
+			keys:  []string{"method", "name", "reason"},
+		},
+		{
+			name:  "RDAPIPResult",
+			value: RDAPIPResult{},
+			keys: []string{
+				"abuse_contacts", "bootstrap_publication", "country_code", "end_address", "endpoint",
+				"events", "fetched_at", "handle", "ip_version", "name", "parent_handle", "query",
+				"redacted", "redactions", "referral_count", "registered_organizations", "registry",
+				"source", "start_address", "status", "type",
+			},
+		},
+		{
+			name:  "RDAPASNResult",
+			value: RDAPASNResult{},
+			keys: []string{
+				"abuse_contacts", "bootstrap_publication", "country_code", "end_autnum", "endpoint",
+				"events", "fetched_at", "handle", "name", "query", "redacted", "redactions",
+				"referral_count", "registered_organizations", "registry", "source", "start_autnum",
+				"status", "type",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/rdap.go
+++ b/rdap.go
@@ -809,17 +809,33 @@ func normalizeRDAPEntitiesAtDepth(values []rawRDAPEntity, depth int) ([]string, 
 }
 
 func deduplicateRDAPEntityReferences(values []RDAPEntityReference) []RDAPEntityReference {
-	seen := make(map[string]struct{}, len(values))
 	result := make([]RDAPEntityReference, 0, len(values))
 	for _, value := range values {
-		key := value.Handle + "\x00" + strings.Join(value.Roles, "\x00")
-		if _, found := seen[key]; found {
+		duplicate := false
+		for _, existing := range result {
+			if existing.Handle == value.Handle && equalStrings(existing.Roles, value.Roles) {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
 			continue
 		}
-		seen[key] = struct{}{}
 		result = append(result, value)
 	}
 	return result
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func extractRDAPOrganizations(raw json.RawMessage) ([]string, error) {

--- a/rdap.go
+++ b/rdap.go
@@ -385,7 +385,7 @@ func (provider RDAPProvider) fetch(ctx context.Context, resolution RDAPBootstrap
 	if err != nil {
 		return rdapHTTPResult{}, err
 	}
-	if err := provider.validateTarget(current, objectType, resource, allowed); err != nil {
+	if err := provider.validateTarget(current, objectType, resource); err != nil {
 		return rdapHTTPResult{finalURL: current}, err
 	}
 	client, err := provider.authoritativeClient()
@@ -452,8 +452,13 @@ func (provider RDAPProvider) fetch(ctx context.Context, resolution RDAPBootstrap
 			if err != nil {
 				return failure, malformedResponseError(fmt.Errorf("invalid RDAP referral URL"))
 			}
-			if err := provider.validateTarget(next, objectType, resource, allowed); err != nil {
+			if err := provider.validateTarget(next, objectType, resource); err != nil {
 				return failure, err
+			}
+			if !strings.EqualFold(current.Host, next.Host) {
+				if _, found := allowed[strings.ToLower(next.Host)]; !found {
+					return failure, malformedResponseError(fmt.Errorf("RDAP referral authority is not bootstrap-authorized"))
+				}
 			}
 			current = next
 		case http.StatusNotFound:
@@ -525,16 +530,13 @@ func buildRDAPQueryURL(baseURL, objectType, resource string) (*url.URL, error) {
 	return base, nil
 }
 
-func (provider RDAPProvider) validateTarget(target *url.URL, objectType, resource string, allowed map[string]struct{}) error {
+func (provider RDAPProvider) validateTarget(target *url.URL, objectType, resource string) error {
 	if target == nil || target.Host == "" || target.User != nil || target.RawQuery != "" || target.Fragment != "" {
 		return malformedResponseError(fmt.Errorf("unsafe RDAP referral URL"))
 	}
 	scheme := strings.ToLower(target.Scheme)
 	if scheme != "https" && !(provider.AllowInsecureHTTP && scheme == "http") {
 		return malformedResponseError(fmt.Errorf("RDAP target must use HTTPS"))
-	}
-	if _, found := allowed[strings.ToLower(target.Host)]; !found {
-		return malformedResponseError(fmt.Errorf("RDAP referral authority is not bootstrap-authorized"))
 	}
 	if !provider.AllowPrivateNetworkTargets && unsafeRDAPHostname(target.Hostname()) {
 		return malformedResponseError(fmt.Errorf("RDAP target is not a public network host"))

--- a/rdap.go
+++ b/rdap.go
@@ -8,15 +8,20 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
 const (
 	// DefaultRDAPMaxReferrals bounds manually followed HTTP redirects.
 	DefaultRDAPMaxReferrals = 3
+	// maxRDAPEntityDepth bounds recursive entity traversal in untrusted RDAP
+	// responses.
+	maxRDAPEntityDepth = 8
 
 	// RDAPSource identifies normalized RDAP registration results.
 	RDAPSource = "rdap"
@@ -170,6 +175,7 @@ type rawRDAPEntity struct {
 	Roles           []string        `json:"roles"`
 	Status          []string        `json:"status"`
 	VCardArray      json.RawMessage `json:"vcardArray"`
+	Entities        []rawRDAPEntity `json:"entities"`
 }
 
 type rawRDAPRedaction struct {
@@ -291,7 +297,11 @@ func (provider RDAPProvider) LookupIPContext(ctx context.Context, value string) 
 	}
 	httpResult, err := provider.fetch(lookupCtx, resolution, "ip", query)
 	if err != nil {
-		return RDAPIPResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), err)
+		endpoint := rdapOrigin(httpResult.finalURL)
+		if endpoint == "" {
+			endpoint = provider.Bootstrap.CacheIdentity()
+		}
+		return RDAPIPResult{}, provider.operationError(operation, endpoint, err)
 	}
 	result, err := parseRDAPIPResult(query, httpResult, time.Now().UTC())
 	if err != nil {
@@ -326,7 +336,11 @@ func (provider RDAPProvider) LookupASNContext(ctx context.Context, value string)
 	}
 	httpResult, err := provider.fetch(lookupCtx, resolution, "autnum", query)
 	if err != nil {
-		return RDAPASNResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), err)
+		endpoint := rdapOrigin(httpResult.finalURL)
+		if endpoint == "" {
+			endpoint = provider.Bootstrap.CacheIdentity()
+		}
+		return RDAPASNResult{}, provider.operationError(operation, endpoint, err)
 	}
 	result, err := parseRDAPASNResult(asn, httpResult, time.Now().UTC())
 	if err != nil {
@@ -372,42 +386,54 @@ func (provider RDAPProvider) fetch(ctx context.Context, resolution RDAPBootstrap
 		return rdapHTTPResult{}, err
 	}
 	if err := provider.validateTarget(current, objectType, resource, allowed); err != nil {
-		return rdapHTTPResult{}, err
+		return rdapHTTPResult{finalURL: current}, err
+	}
+	client, err := provider.authoritativeClient()
+	if err != nil {
+		return rdapHTTPResult{finalURL: current}, err
 	}
 
 	visited := make(map[string]struct{})
 	for referralCount := 0; ; referralCount++ {
+		failure := rdapHTTPResult{
+			finalURL:             current,
+			referralCount:        referralCount,
+			bootstrapPublication: resolution.Publication,
+		}
 		currentKey := current.String()
 		if _, found := visited[currentKey]; found {
-			return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("RDAP referral loop"))
+			return failure, malformedResponseError(fmt.Errorf("RDAP referral loop"))
 		}
 		visited[currentKey] = struct{}{}
 
 		request, err := http.NewRequestWithContext(ctx, http.MethodGet, current.String(), nil)
 		if err != nil {
-			return rdapHTTPResult{}, invalidInputError("invalid RDAP request URL")
+			return failure, invalidInputError("invalid RDAP request URL")
 		}
 		request.Header.Set("Accept", "application/rdap+json")
 		request.Header.Set("User-Agent", AppName)
 
-		response, err := rdapNoRedirectClient(provider.Client).Do(request)
+		response, err := client.Do(request)
 		if err != nil {
-			return rdapHTTPResult{}, classifyContextTransportError(ctx, err)
+			if errors.Is(err, ErrMalformedResponse) {
+				return failure, err
+			}
+			return failure, classifyContextTransportError(ctx, err)
 		}
 
 		switch response.StatusCode {
 		case http.StatusOK:
 			if !isRDAPJSONContentType(response.Header.Get("Content-Type"), "application/rdap+json") {
 				response.Body.Close()
-				return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("unexpected RDAP content type"))
+				return failure, malformedResponseError(fmt.Errorf("unexpected RDAP content type"))
 			}
 			body, readErr := readBoundedHTTPBody(response.Body, provider.MaxResponseBytes)
 			response.Body.Close()
 			if readErr != nil {
 				if errors.Is(readErr, ErrResponseTooLarge) {
-					return rdapHTTPResult{}, readErr
+					return failure, readErr
 				}
-				return rdapHTTPResult{}, classifyContextTransportError(ctx, readErr)
+				return failure, classifyContextTransportError(ctx, readErr)
 			}
 			return rdapHTTPResult{
 				body:                 body,
@@ -420,30 +446,72 @@ func (provider RDAPProvider) fetch(ctx context.Context, resolution RDAPBootstrap
 			location := response.Header.Get("Location")
 			response.Body.Close()
 			if referralCount >= provider.MaxReferrals {
-				return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("RDAP referral limit exceeded"))
+				return failure, malformedResponseError(fmt.Errorf("RDAP referral limit exceeded"))
 			}
 			next, err := current.Parse(location)
 			if err != nil {
-				return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("invalid RDAP referral URL"))
+				return failure, malformedResponseError(fmt.Errorf("invalid RDAP referral URL"))
 			}
 			if err := provider.validateTarget(next, objectType, resource, allowed); err != nil {
-				return rdapHTTPResult{}, err
+				return failure, err
 			}
 			current = next
 		case http.StatusNotFound:
 			response.Body.Close()
-			return rdapHTTPResult{}, noRecordsError("RDAP registration lookup")
+			return failure, noRecordsError("RDAP registration lookup")
 		case http.StatusTooManyRequests:
 			response.Body.Close()
-			return rdapHTTPResult{}, ErrRateLimited
+			return failure, ErrRateLimited
 		default:
 			status := response.StatusCode
 			response.Body.Close()
 			if status >= 500 {
-				return rdapHTTPResult{}, fmt.Errorf("%w: RDAP HTTP status %d", ErrConnection, status)
+				return failure, fmt.Errorf("%w: RDAP HTTP status %d", ErrConnection, status)
 			}
-			return rdapHTTPResult{}, fmt.Errorf("%w: RDAP HTTP status %d", ErrProviderRejected, status)
+			return failure, fmt.Errorf("%w: RDAP HTTP status %d", ErrProviderRejected, status)
 		}
+	}
+}
+
+func (provider RDAPProvider) authoritativeClient() (*http.Client, error) {
+	client := rdapNoRedirectClient(provider.Client)
+	if provider.AllowPrivateNetworkTargets {
+		return client, nil
+	}
+
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		return nil, invalidInputError("public-only RDAP requires an HTTP transport with dial-time address validation")
+	}
+	clonedTransport := httpTransport.Clone()
+	// A proxy may resolve the target remotely, outside this process's
+	// dial-time address policy. Public-only mode therefore connects directly.
+	clonedTransport.Proxy = nil
+	clonedTransport.DialContext = publicRDAPDialer().DialContext
+	clonedTransport.DialTLSContext = nil
+	clonedTransport.DialTLS = nil
+	client.Transport = clonedTransport
+	return client, nil
+}
+
+func publicRDAPDialer() *net.Dialer {
+	return &net.Dialer{
+		KeepAlive: time.Second * time.Duration(SocketKeepAlive),
+		ControlContext: func(_ context.Context, _, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return malformedResponseError(fmt.Errorf("invalid resolved RDAP target"))
+			}
+			ip := net.ParseIP(strings.Trim(host, "[]"))
+			if ip == nil || unsafeRDAPIPAddress(ip) {
+				return malformedResponseError(fmt.Errorf("RDAP target resolved to a non-public or special-use address"))
+			}
+			return nil
+		},
 	}
 }
 
@@ -486,8 +554,59 @@ func unsafeRDAPHostname(hostname string) bool {
 		return true
 	}
 	ip := net.ParseIP(hostname)
-	return ip != nil && (ip.IsPrivate() || ip.IsLoopback() || ip.IsUnspecified() ||
-		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast())
+	return ip != nil && unsafeRDAPIPAddress(ip)
+}
+
+var rdapSpecialUsePrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.31.196.0/24"),
+	netip.MustParsePrefix("192.52.193.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("192.175.48.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("::ffff:0:0/96"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("64:ff9b:1::/48"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("100:0:0:1::/64"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("2620:4f:8000::/48"),
+	netip.MustParsePrefix("3fff::/20"),
+	netip.MustParsePrefix("5f00::/16"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+}
+
+func unsafeRDAPIPAddress(ip net.IP) bool {
+	address, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return true
+	}
+	address = address.Unmap()
+	if !address.IsGlobalUnicast() {
+		return true
+	}
+	for _, prefix := range rdapSpecialUsePrefixes {
+		if prefix.Contains(address) {
+			return true
+		}
+	}
+	return false
 }
 
 func parseRDAPIPResult(query string, response rdapHTTPResult, fetchedAt time.Time) (RDAPIPResult, error) {
@@ -636,6 +755,16 @@ func normalizeRDAPEvents(values []rawRDAPEvent) ([]RDAPEvent, error) {
 }
 
 func normalizeRDAPEntities(values []rawRDAPEntity) ([]string, []RDAPEntityReference, bool, error) {
+	return normalizeRDAPEntitiesAtDepth(values, 0)
+}
+
+func normalizeRDAPEntitiesAtDepth(values []rawRDAPEntity, depth int) ([]string, []RDAPEntityReference, bool, error) {
+	if len(values) == 0 {
+		return nil, nil, false, nil
+	}
+	if depth > maxRDAPEntityDepth {
+		return nil, nil, false, malformedResponseError(fmt.Errorf("RDAP entity nesting exceeds the supported depth"))
+	}
 	var organizations []string
 	var abuseContacts []RDAPEntityReference
 	redacted := false
@@ -665,8 +794,30 @@ func normalizeRDAPEntities(values []rawRDAPEntity) ([]string, []RDAPEntityRefere
 			}
 			organizations = append(organizations, entityOrganizations...)
 		}
+		nestedOrganizations, nestedAbuseContacts, nestedRedacted, err :=
+			normalizeRDAPEntitiesAtDepth(entity.Entities, depth+1)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		organizations = append(organizations, nestedOrganizations...)
+		abuseContacts = append(abuseContacts, nestedAbuseContacts...)
+		redacted = redacted || nestedRedacted
 	}
-	return deduplicateStrings(organizations), abuseContacts, redacted, nil
+	return deduplicateStrings(organizations), deduplicateRDAPEntityReferences(abuseContacts), redacted, nil
+}
+
+func deduplicateRDAPEntityReferences(values []RDAPEntityReference) []RDAPEntityReference {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]RDAPEntityReference, 0, len(values))
+	for _, value := range values {
+		key := value.Handle + "\x00" + strings.Join(value.Roles, "\x00")
+		if _, found := seen[key]; found {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 func extractRDAPOrganizations(raw json.RawMessage) ([]string, error) {

--- a/rdap.go
+++ b/rdap.go
@@ -809,33 +809,34 @@ func normalizeRDAPEntitiesAtDepth(values []rawRDAPEntity, depth int) ([]string, 
 }
 
 func deduplicateRDAPEntityReferences(values []RDAPEntityReference) []RDAPEntityReference {
+	seen := make(map[string]struct{}, len(values))
 	result := make([]RDAPEntityReference, 0, len(values))
 	for _, value := range values {
-		duplicate := false
-		for _, existing := range result {
-			if existing.Handle == value.Handle && equalStrings(existing.Roles, value.Roles) {
-				duplicate = true
-				break
-			}
-		}
-		if duplicate {
+		key := rdapEntityReferenceKey(value)
+		if _, found := seen[key]; found {
 			continue
 		}
+		seen[key] = struct{}{}
 		result = append(result, value)
 	}
 	return result
 }
 
-func equalStrings(left, right []string) bool {
-	if len(left) != len(right) {
-		return false
+func rdapEntityReferenceKey(value RDAPEntityReference) string {
+	var key strings.Builder
+	writeRDAPLengthPrefixedString(&key, value.Handle)
+	key.WriteByte('#')
+	key.WriteString(strconv.Itoa(len(value.Roles)))
+	for _, role := range value.Roles {
+		writeRDAPLengthPrefixedString(&key, role)
 	}
-	for index := range left {
-		if left[index] != right[index] {
-			return false
-		}
-	}
-	return true
+	return key.String()
+}
+
+func writeRDAPLengthPrefixedString(key *strings.Builder, value string) {
+	key.WriteString(strconv.Itoa(len(value)))
+	key.WriteByte(':')
+	key.WriteString(value)
 }
 
 func extractRDAPOrganizations(raw json.RawMessage) ([]string, error) {

--- a/rdap.go
+++ b/rdap.go
@@ -1,0 +1,825 @@
+package pwhois
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultRDAPMaxReferrals bounds manually followed HTTP redirects.
+	DefaultRDAPMaxReferrals = 3
+
+	// RDAPSource identifies normalized RDAP registration results.
+	RDAPSource = "rdap"
+	// RDAPProtocolVersion identifies the RDAP HTTP/JSON contract in cache keys.
+	RDAPProtocolVersion = "rdap-http-rfc9082-rfc9083"
+	// RDAPParserVersion identifies the privacy-minimized parser contract.
+	RDAPParserVersion = "rdap-registration-v1"
+	// RDAPIPResultSchemaVersion identifies the normalized IP result shape.
+	RDAPIPResultSchemaVersion = "rdap-ip-result-v1"
+	// RDAPASNResultSchemaVersion identifies the normalized ASN result shape.
+	RDAPASNResultSchemaVersion = "rdap-asn-result-v1"
+)
+
+// RDAPProvider configures explicit IP and ASN registration lookups. It uses
+// IANA bootstrap data by default and follows only bounded, bootstrap-authorized
+// referrals. It does not expose complete RDAP entity or jCard contact data.
+type RDAPProvider struct {
+	Client    *http.Client
+	Bootstrap RDAPBootstrapResolver
+	Timeout   time.Duration
+	// MaxResponseBytes bounds one final RDAP response before JSON parsing.
+	MaxResponseBytes int64
+	// MaxReferrals bounds manually followed HTTP redirects. A value less than
+	// or equal to zero uses DefaultRDAPMaxReferrals.
+	MaxReferrals int
+	// AllowInsecureHTTP and AllowPrivateNetworkTargets exist for controlled
+	// local test infrastructure. Do not enable them for public RDAP traffic.
+	AllowInsecureHTTP          bool
+	AllowPrivateNetworkTargets bool
+}
+
+// NewRDAPProvider returns a provider whose IANA bootstrap and authoritative
+// RDAP requests share one HTTP client while retaining a provider-owned
+// bootstrap cache. A nil client uses http.DefaultClient.
+func NewRDAPProvider(client *http.Client) RDAPProvider {
+	return RDAPProvider{
+		Client: client,
+		Bootstrap: &IANARDAPBootstrapResolver{
+			Client: client,
+		},
+	}
+}
+
+// RDAPEvent is a public provider event without the optional eventActor contact
+// field.
+type RDAPEvent struct {
+	Action string    `json:"action"`
+	Date   time.Time `json:"date"`
+}
+
+// RDAPEntityReference retains a public entity handle and its roles without
+// copying email, telephone, postal-address, or personal-name fields.
+type RDAPEntityReference struct {
+	Handle string   `json:"handle"`
+	Roles  []string `json:"roles"`
+}
+
+// RDAPRedactionIndicator reports a provider-declared redaction without
+// retaining JSON paths that might describe omitted contact fields.
+type RDAPRedactionIndicator struct {
+	Name   string `json:"name"`
+	Method string `json:"method"`
+	Reason string `json:"reason"`
+}
+
+// RDAPIPResult is privacy-minimized IP allocation or assignment context. It is
+// registration data, not observed routing, geolocation, or sender attribution.
+type RDAPIPResult struct {
+	Query                   string                   `json:"query"`
+	StartAddress            string                   `json:"start_address"`
+	EndAddress              string                   `json:"end_address"`
+	IPVersion               string                   `json:"ip_version"`
+	Handle                  string                   `json:"handle"`
+	Name                    string                   `json:"name"`
+	Type                    string                   `json:"type"`
+	CountryCode             string                   `json:"country_code"`
+	ParentHandle            string                   `json:"parent_handle"`
+	Status                  []string                 `json:"status"`
+	Events                  []RDAPEvent              `json:"events"`
+	RegisteredOrganizations []string                 `json:"registered_organizations"`
+	AbuseContacts           []RDAPEntityReference    `json:"abuse_contacts"`
+	Redacted                bool                     `json:"redacted"`
+	Redactions              []RDAPRedactionIndicator `json:"redactions"`
+	Registry                string                   `json:"registry"`
+	Endpoint                string                   `json:"endpoint"`
+	ReferralCount           int                      `json:"referral_count"`
+	BootstrapPublication    time.Time                `json:"bootstrap_publication"`
+	Source                  string                   `json:"source"`
+	FetchedAt               time.Time                `json:"fetched_at"`
+}
+
+// RDAPASNResult is privacy-minimized autonomous-system registration context.
+// It is registration data and does not assert that the ASN currently
+// originates a route.
+type RDAPASNResult struct {
+	Query                   uint32                   `json:"query"`
+	StartAutnum             uint32                   `json:"start_autnum"`
+	EndAutnum               uint32                   `json:"end_autnum"`
+	Handle                  string                   `json:"handle"`
+	Name                    string                   `json:"name"`
+	Type                    string                   `json:"type"`
+	CountryCode             string                   `json:"country_code"`
+	Status                  []string                 `json:"status"`
+	Events                  []RDAPEvent              `json:"events"`
+	RegisteredOrganizations []string                 `json:"registered_organizations"`
+	AbuseContacts           []RDAPEntityReference    `json:"abuse_contacts"`
+	Redacted                bool                     `json:"redacted"`
+	Redactions              []RDAPRedactionIndicator `json:"redactions"`
+	Registry                string                   `json:"registry"`
+	Endpoint                string                   `json:"endpoint"`
+	ReferralCount           int                      `json:"referral_count"`
+	BootstrapPublication    time.Time                `json:"bootstrap_publication"`
+	Source                  string                   `json:"source"`
+	FetchedAt               time.Time                `json:"fetched_at"`
+}
+
+type rdapHTTPResult struct {
+	body                 []byte
+	finalURL             *url.URL
+	referralCount        int
+	bootstrapPublication time.Time
+}
+
+type rawRDAPObject struct {
+	RDAPConformance []string           `json:"rdapConformance"`
+	ObjectClassName string             `json:"objectClassName"`
+	Handle          string             `json:"handle"`
+	StartAddress    string             `json:"startAddress"`
+	EndAddress      string             `json:"endAddress"`
+	IPVersion       string             `json:"ipVersion"`
+	StartAutnum     *uint64            `json:"startAutnum"`
+	EndAutnum       *uint64            `json:"endAutnum"`
+	Name            string             `json:"name"`
+	Type            string             `json:"type"`
+	Country         string             `json:"country"`
+	ParentHandle    string             `json:"parentHandle"`
+	Status          []string           `json:"status"`
+	Events          []rawRDAPEvent     `json:"events"`
+	Entities        []rawRDAPEntity    `json:"entities"`
+	Redacted        []rawRDAPRedaction `json:"redacted"`
+}
+
+type rawRDAPEvent struct {
+	Action string `json:"eventAction"`
+	Date   string `json:"eventDate"`
+}
+
+type rawRDAPEntity struct {
+	ObjectClassName string          `json:"objectClassName"`
+	Handle          string          `json:"handle"`
+	Roles           []string        `json:"roles"`
+	Status          []string        `json:"status"`
+	VCardArray      json.RawMessage `json:"vcardArray"`
+}
+
+type rawRDAPRedaction struct {
+	Name struct {
+		Type        string `json:"type"`
+		Description string `json:"description"`
+	} `json:"name"`
+	Method string `json:"method"`
+	Reason struct {
+		Type        string `json:"type"`
+		Description string `json:"description"`
+	} `json:"reason"`
+}
+
+type normalizedRDAPCommon struct {
+	handle                  string
+	name                    string
+	recordType              string
+	countryCode             string
+	status                  []string
+	events                  []RDAPEvent
+	registeredOrganizations []string
+	abuseContacts           []RDAPEntityReference
+	redacted                bool
+	redactions              []RDAPRedactionIndicator
+}
+
+func (provider RDAPProvider) configured() RDAPProvider {
+	if provider.Bootstrap == nil {
+		provider.Bootstrap = defaultIANARDAPBootstrapResolver
+	}
+	if provider.Timeout <= 0 {
+		provider.Timeout = time.Second * time.Duration(SocketTimeout)
+	}
+	if provider.MaxResponseBytes <= 0 {
+		provider.MaxResponseBytes = DefaultMaxResponseBytes
+	}
+	if provider.MaxReferrals <= 0 {
+		provider.MaxReferrals = DefaultRDAPMaxReferrals
+	}
+	return provider
+}
+
+func (provider RDAPProvider) operationError(operation, endpoint string, err error) error {
+	return &OperationError{Operation: operation, Server: endpoint, Err: err}
+}
+
+// IPCacheKeySpec returns the source-aware identity for an RDAP IP lookup.
+func (provider RDAPProvider) IPCacheKeySpec(value string) (CacheKeySpec, error) {
+	provider = provider.configured()
+	ip := net.ParseIP(strings.TrimSpace(value))
+	if ip == nil {
+		return CacheKeySpec{}, invalidInputError("invalid IP address")
+	}
+	return provider.cacheKeySpec("ip", ip.String(), RDAPIPResultSchemaVersion)
+}
+
+// ASNCacheKeySpec returns the source-aware identity for an RDAP ASN lookup.
+func (provider RDAPProvider) ASNCacheKeySpec(value string) (CacheKeySpec, error) {
+	provider = provider.configured()
+	asn, err := normalizeRDAPASN(value)
+	if err != nil {
+		return CacheKeySpec{}, err
+	}
+	return provider.cacheKeySpec("autnum", strconv.FormatUint(uint64(asn), 10), RDAPASNResultSchemaVersion)
+}
+
+func (provider RDAPProvider) cacheKeySpec(objectType, query, schema string) (CacheKeySpec, error) {
+	identity := strings.TrimSpace(provider.Bootstrap.CacheIdentity())
+	if identity == "" {
+		return CacheKeySpec{}, invalidInputError("RDAP bootstrap cache identity is required")
+	}
+	transport := "https-only"
+	if provider.AllowInsecureHTTP {
+		transport = "http-allowed"
+	}
+	targetScope := "public-only"
+	if provider.AllowPrivateNetworkTargets {
+		targetScope = "private-allowed"
+	}
+	return CacheKeySpec{
+		Source:          RDAPSource,
+		Endpoint:        identity,
+		Protocol:        RDAPProtocolVersion,
+		NormalizedQuery: query,
+		Options: map[string]string{
+			"object":        objectType,
+			"max_referrals": strconv.Itoa(provider.MaxReferrals),
+			"privacy":       "organization-and-references-only",
+			"target_scope":  targetScope,
+			"transport":     transport,
+		},
+		ParserVersion:       RDAPParserVersion,
+		ResultSchemaVersion: schema,
+	}, nil
+}
+
+// LookupIPContext returns authoritative RDAP allocation or assignment context
+// for one IP address. Contact data is privacy-minimized to organization names
+// and abuse entity handles.
+func (provider RDAPProvider) LookupIPContext(ctx context.Context, value string) (RDAPIPResult, error) {
+	const operation = "lookup RDAP IP registration"
+
+	provider = provider.configured()
+	if ctx == nil {
+		return RDAPIPResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), invalidInputError("context must not be nil"))
+	}
+	ip := net.ParseIP(strings.TrimSpace(value))
+	if ip == nil {
+		return RDAPIPResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), invalidInputError("invalid IP address"))
+	}
+	query := ip.String()
+
+	lookupCtx, cancel := context.WithTimeout(ctx, provider.Timeout)
+	defer cancel()
+	resolution, err := provider.Bootstrap.ResolveIP(lookupCtx, ip)
+	if err != nil {
+		return RDAPIPResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), err)
+	}
+	httpResult, err := provider.fetch(lookupCtx, resolution, "ip", query)
+	if err != nil {
+		return RDAPIPResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), err)
+	}
+	result, err := parseRDAPIPResult(query, httpResult, time.Now().UTC())
+	if err != nil {
+		return RDAPIPResult{}, provider.operationError(operation, rdapOrigin(httpResult.finalURL), err)
+	}
+	if err := lookupCtx.Err(); err != nil {
+		return RDAPIPResult{}, provider.operationError(operation, rdapOrigin(httpResult.finalURL), classifyTransportError(err))
+	}
+	return result, nil
+}
+
+// LookupASNContext returns authoritative RDAP registration context for one
+// autonomous system number.
+func (provider RDAPProvider) LookupASNContext(ctx context.Context, value string) (RDAPASNResult, error) {
+	const operation = "lookup RDAP ASN registration"
+
+	provider = provider.configured()
+	if ctx == nil {
+		return RDAPASNResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), invalidInputError("context must not be nil"))
+	}
+	asn, err := normalizeRDAPASN(value)
+	if err != nil {
+		return RDAPASNResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), err)
+	}
+	query := strconv.FormatUint(uint64(asn), 10)
+
+	lookupCtx, cancel := context.WithTimeout(ctx, provider.Timeout)
+	defer cancel()
+	resolution, err := provider.Bootstrap.ResolveASN(lookupCtx, asn)
+	if err != nil {
+		return RDAPASNResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), err)
+	}
+	httpResult, err := provider.fetch(lookupCtx, resolution, "autnum", query)
+	if err != nil {
+		return RDAPASNResult{}, provider.operationError(operation, provider.Bootstrap.CacheIdentity(), err)
+	}
+	result, err := parseRDAPASNResult(asn, httpResult, time.Now().UTC())
+	if err != nil {
+		return RDAPASNResult{}, provider.operationError(operation, rdapOrigin(httpResult.finalURL), err)
+	}
+	if err := lookupCtx.Err(); err != nil {
+		return RDAPASNResult{}, provider.operationError(operation, rdapOrigin(httpResult.finalURL), classifyTransportError(err))
+	}
+	return result, nil
+}
+
+func normalizeRDAPASN(value string) (uint32, error) {
+	normalized, err := normalizeASN(value)
+	if err != nil {
+		return 0, err
+	}
+	asn, err := strconv.ParseUint(normalized, 10, 32)
+	if err != nil {
+		return 0, invalidInputError("ASN must fit in 32 bits")
+	}
+	return uint32(asn), nil
+}
+
+func (provider RDAPProvider) fetch(ctx context.Context, resolution RDAPBootstrapResolution, objectType, resource string) (rdapHTTPResult, error) {
+	if len(resolution.BaseURLs) == 0 {
+		return rdapHTTPResult{}, noRecordsError("RDAP bootstrap resolution")
+	}
+	if resolution.Publication.IsZero() {
+		return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("RDAP bootstrap publication time is required"))
+	}
+
+	allowed := make(map[string]struct{}, len(resolution.AllowedAuthorities))
+	for _, authority := range resolution.AllowedAuthorities {
+		authority = strings.ToLower(strings.TrimSpace(authority))
+		if authority == "" {
+			return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("empty bootstrap referral authority"))
+		}
+		allowed[authority] = struct{}{}
+	}
+
+	current, err := buildRDAPQueryURL(resolution.BaseURLs[0], objectType, resource)
+	if err != nil {
+		return rdapHTTPResult{}, err
+	}
+	if err := provider.validateTarget(current, objectType, resource, allowed); err != nil {
+		return rdapHTTPResult{}, err
+	}
+
+	visited := make(map[string]struct{})
+	for referralCount := 0; ; referralCount++ {
+		currentKey := current.String()
+		if _, found := visited[currentKey]; found {
+			return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("RDAP referral loop"))
+		}
+		visited[currentKey] = struct{}{}
+
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, current.String(), nil)
+		if err != nil {
+			return rdapHTTPResult{}, invalidInputError("invalid RDAP request URL")
+		}
+		request.Header.Set("Accept", "application/rdap+json")
+		request.Header.Set("User-Agent", AppName)
+
+		response, err := rdapNoRedirectClient(provider.Client).Do(request)
+		if err != nil {
+			return rdapHTTPResult{}, classifyContextTransportError(ctx, err)
+		}
+
+		switch response.StatusCode {
+		case http.StatusOK:
+			if !isRDAPJSONContentType(response.Header.Get("Content-Type"), "application/rdap+json") {
+				response.Body.Close()
+				return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("unexpected RDAP content type"))
+			}
+			body, readErr := readBoundedHTTPBody(response.Body, provider.MaxResponseBytes)
+			response.Body.Close()
+			if readErr != nil {
+				if errors.Is(readErr, ErrResponseTooLarge) {
+					return rdapHTTPResult{}, readErr
+				}
+				return rdapHTTPResult{}, classifyContextTransportError(ctx, readErr)
+			}
+			return rdapHTTPResult{
+				body:                 body,
+				finalURL:             current,
+				referralCount:        referralCount,
+				bootstrapPublication: resolution.Publication,
+			}, nil
+		case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther,
+			http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+			location := response.Header.Get("Location")
+			response.Body.Close()
+			if referralCount >= provider.MaxReferrals {
+				return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("RDAP referral limit exceeded"))
+			}
+			next, err := current.Parse(location)
+			if err != nil {
+				return rdapHTTPResult{}, malformedResponseError(fmt.Errorf("invalid RDAP referral URL"))
+			}
+			if err := provider.validateTarget(next, objectType, resource, allowed); err != nil {
+				return rdapHTTPResult{}, err
+			}
+			current = next
+		case http.StatusNotFound:
+			response.Body.Close()
+			return rdapHTTPResult{}, noRecordsError("RDAP registration lookup")
+		case http.StatusTooManyRequests:
+			response.Body.Close()
+			return rdapHTTPResult{}, ErrRateLimited
+		default:
+			status := response.StatusCode
+			response.Body.Close()
+			if status >= 500 {
+				return rdapHTTPResult{}, fmt.Errorf("%w: RDAP HTTP status %d", ErrConnection, status)
+			}
+			return rdapHTTPResult{}, fmt.Errorf("%w: RDAP HTTP status %d", ErrProviderRejected, status)
+		}
+	}
+}
+
+func buildRDAPQueryURL(baseURL, objectType, resource string) (*url.URL, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil || base.Host == "" || base.User != nil || base.RawQuery != "" ||
+		base.Fragment != "" || !strings.HasSuffix(base.Path, "/") {
+		return nil, malformedResponseError(fmt.Errorf("invalid RDAP bootstrap base URL"))
+	}
+	base.Path += objectType + "/" + resource
+	return base, nil
+}
+
+func (provider RDAPProvider) validateTarget(target *url.URL, objectType, resource string, allowed map[string]struct{}) error {
+	if target == nil || target.Host == "" || target.User != nil || target.RawQuery != "" || target.Fragment != "" {
+		return malformedResponseError(fmt.Errorf("unsafe RDAP referral URL"))
+	}
+	scheme := strings.ToLower(target.Scheme)
+	if scheme != "https" && !(provider.AllowInsecureHTTP && scheme == "http") {
+		return malformedResponseError(fmt.Errorf("RDAP target must use HTTPS"))
+	}
+	if _, found := allowed[strings.ToLower(target.Host)]; !found {
+		return malformedResponseError(fmt.Errorf("RDAP referral authority is not bootstrap-authorized"))
+	}
+	if !provider.AllowPrivateNetworkTargets && unsafeRDAPHostname(target.Hostname()) {
+		return malformedResponseError(fmt.Errorf("RDAP target is not a public network host"))
+	}
+
+	path := strings.TrimSuffix(target.Path, "/")
+	if !strings.HasSuffix(path, "/"+objectType+"/"+resource) {
+		return malformedResponseError(fmt.Errorf("RDAP referral changed the requested resource"))
+	}
+	return nil
+}
+
+func unsafeRDAPHostname(hostname string) bool {
+	hostname = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(hostname), "."))
+	if hostname == "" || hostname == "localhost" || strings.HasSuffix(hostname, ".localhost") ||
+		strings.HasSuffix(hostname, ".local") {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	return ip != nil && (ip.IsPrivate() || ip.IsLoopback() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast())
+}
+
+func parseRDAPIPResult(query string, response rdapHTTPResult, fetchedAt time.Time) (RDAPIPResult, error) {
+	raw, common, err := parseRDAPObject(response.body, "ip network")
+	if err != nil {
+		return RDAPIPResult{}, err
+	}
+
+	queryIP := net.ParseIP(query)
+	startIP := net.ParseIP(strings.TrimSpace(raw.StartAddress))
+	endIP := net.ParseIP(strings.TrimSpace(raw.EndAddress))
+	if queryIP == nil || startIP == nil || endIP == nil {
+		return RDAPIPResult{}, malformedResponseError(fmt.Errorf("invalid RDAP IP range"))
+	}
+	wantV4 := queryIP.To4() != nil
+	if (startIP.To4() != nil) != wantV4 || (endIP.To4() != nil) != wantV4 {
+		return RDAPIPResult{}, malformedResponseError(fmt.Errorf("RDAP IP range address family mismatch"))
+	}
+	if compareIP(startIP, endIP) > 0 || compareIP(queryIP, startIP) < 0 || compareIP(queryIP, endIP) > 0 {
+		return RDAPIPResult{}, malformedResponseError(fmt.Errorf("RDAP IP range does not contain the query"))
+	}
+	ipVersion := strings.ToLower(strings.TrimSpace(raw.IPVersion))
+	if (wantV4 && ipVersion != "v4") || (!wantV4 && ipVersion != "v6") {
+		return RDAPIPResult{}, malformedResponseError(fmt.Errorf("invalid RDAP IP version"))
+	}
+
+	return RDAPIPResult{
+		Query:                   query,
+		StartAddress:            canonicalIP(startIP),
+		EndAddress:              canonicalIP(endIP),
+		IPVersion:               ipVersion,
+		Handle:                  common.handle,
+		Name:                    common.name,
+		Type:                    common.recordType,
+		CountryCode:             common.countryCode,
+		ParentHandle:            strings.TrimSpace(raw.ParentHandle),
+		Status:                  common.status,
+		Events:                  common.events,
+		RegisteredOrganizations: common.registeredOrganizations,
+		AbuseContacts:           common.abuseContacts,
+		Redacted:                common.redacted,
+		Redactions:              common.redactions,
+		Registry:                strings.ToLower(response.finalURL.Hostname()),
+		Endpoint:                rdapOrigin(response.finalURL),
+		ReferralCount:           response.referralCount,
+		BootstrapPublication:    response.bootstrapPublication,
+		Source:                  RDAPSource,
+		FetchedAt:               fetchedAt,
+	}, nil
+}
+
+func parseRDAPASNResult(query uint32, response rdapHTTPResult, fetchedAt time.Time) (RDAPASNResult, error) {
+	raw, common, err := parseRDAPObject(response.body, "autnum")
+	if err != nil {
+		return RDAPASNResult{}, err
+	}
+	if raw.StartAutnum == nil || raw.EndAutnum == nil || *raw.StartAutnum > uint64(^uint32(0)) ||
+		*raw.EndAutnum > uint64(^uint32(0)) || *raw.StartAutnum > *raw.EndAutnum ||
+		uint64(query) < *raw.StartAutnum || uint64(query) > *raw.EndAutnum {
+		return RDAPASNResult{}, malformedResponseError(fmt.Errorf("invalid RDAP ASN range"))
+	}
+
+	return RDAPASNResult{
+		Query:                   query,
+		StartAutnum:             uint32(*raw.StartAutnum),
+		EndAutnum:               uint32(*raw.EndAutnum),
+		Handle:                  common.handle,
+		Name:                    common.name,
+		Type:                    common.recordType,
+		CountryCode:             common.countryCode,
+		Status:                  common.status,
+		Events:                  common.events,
+		RegisteredOrganizations: common.registeredOrganizations,
+		AbuseContacts:           common.abuseContacts,
+		Redacted:                common.redacted,
+		Redactions:              common.redactions,
+		Registry:                strings.ToLower(response.finalURL.Hostname()),
+		Endpoint:                rdapOrigin(response.finalURL),
+		ReferralCount:           response.referralCount,
+		BootstrapPublication:    response.bootstrapPublication,
+		Source:                  RDAPSource,
+		FetchedAt:               fetchedAt,
+	}, nil
+}
+
+func parseRDAPObject(body []byte, objectClass string) (rawRDAPObject, normalizedRDAPCommon, error) {
+	var raw rawRDAPObject
+	if err := decodeSingleJSON(body, &raw); err != nil {
+		return rawRDAPObject{}, normalizedRDAPCommon{}, malformedResponseError(fmt.Errorf("decode RDAP response: %w", err))
+	}
+	if !strings.EqualFold(strings.TrimSpace(raw.ObjectClassName), objectClass) {
+		return rawRDAPObject{}, normalizedRDAPCommon{}, malformedResponseError(fmt.Errorf("unexpected RDAP object class"))
+	}
+	if !containsFold(raw.RDAPConformance, "rdap_level_0") {
+		return rawRDAPObject{}, normalizedRDAPCommon{}, malformedResponseError(fmt.Errorf("missing RDAP level 0 conformance"))
+	}
+
+	countryCode := strings.ToUpper(strings.TrimSpace(raw.Country))
+	if countryCode != "" && (len(countryCode) != 2 ||
+		countryCode[0] < 'A' || countryCode[0] > 'Z' ||
+		countryCode[1] < 'A' || countryCode[1] > 'Z') {
+		return rawRDAPObject{}, normalizedRDAPCommon{}, malformedResponseError(fmt.Errorf("invalid RDAP country code"))
+	}
+	events, err := normalizeRDAPEvents(raw.Events)
+	if err != nil {
+		return rawRDAPObject{}, normalizedRDAPCommon{}, err
+	}
+	organizations, abuseContacts, entityRedacted, err := normalizeRDAPEntities(raw.Entities)
+	if err != nil {
+		return rawRDAPObject{}, normalizedRDAPCommon{}, err
+	}
+	redactions, err := normalizeRDAPRedactions(raw.Redacted)
+	if err != nil {
+		return rawRDAPObject{}, normalizedRDAPCommon{}, err
+	}
+
+	status := normalizeRDAPStrings(raw.Status)
+	return raw, normalizedRDAPCommon{
+		handle:                  strings.TrimSpace(raw.Handle),
+		name:                    strings.TrimSpace(raw.Name),
+		recordType:              strings.TrimSpace(raw.Type),
+		countryCode:             countryCode,
+		status:                  status,
+		events:                  events,
+		registeredOrganizations: organizations,
+		abuseContacts:           abuseContacts,
+		redacted:                len(redactions) != 0 || entityRedacted || hasPrivacyStatus(status),
+		redactions:              redactions,
+	}, nil
+}
+
+func normalizeRDAPEvents(values []rawRDAPEvent) ([]RDAPEvent, error) {
+	events := make([]RDAPEvent, 0, len(values))
+	for _, value := range values {
+		action := strings.TrimSpace(value.Action)
+		if action == "" {
+			return nil, malformedResponseError(fmt.Errorf("RDAP event is missing an action"))
+		}
+		date, err := time.Parse(time.RFC3339, strings.TrimSpace(value.Date))
+		if err != nil {
+			return nil, malformedResponseError(fmt.Errorf("invalid RDAP event date"))
+		}
+		events = append(events, RDAPEvent{Action: action, Date: date})
+	}
+	return events, nil
+}
+
+func normalizeRDAPEntities(values []rawRDAPEntity) ([]string, []RDAPEntityReference, bool, error) {
+	var organizations []string
+	var abuseContacts []RDAPEntityReference
+	redacted := false
+
+	for _, entity := range values {
+		if !strings.EqualFold(strings.TrimSpace(entity.ObjectClassName), "entity") {
+			return nil, nil, false, malformedResponseError(fmt.Errorf("unexpected RDAP entity object class"))
+		}
+		roles := normalizeRDAPStrings(entity.Roles)
+		status := normalizeRDAPStrings(entity.Status)
+		if hasPrivacyStatus(status) {
+			redacted = true
+		}
+		if containsFold(roles, "abuse") {
+			handle := strings.TrimSpace(entity.Handle)
+			if handle != "" {
+				abuseContacts = append(abuseContacts, RDAPEntityReference{
+					Handle: handle,
+					Roles:  roles,
+				})
+			}
+		}
+		if containsFold(roles, "registrant") && len(entity.VCardArray) != 0 {
+			entityOrganizations, err := extractRDAPOrganizations(entity.VCardArray)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			organizations = append(organizations, entityOrganizations...)
+		}
+	}
+	return deduplicateStrings(organizations), abuseContacts, redacted, nil
+}
+
+func extractRDAPOrganizations(raw json.RawMessage) ([]string, error) {
+	var card []json.RawMessage
+	if err := json.Unmarshal(raw, &card); err != nil || len(card) != 2 {
+		return nil, malformedResponseError(fmt.Errorf("invalid RDAP jCard"))
+	}
+	var cardType string
+	if err := json.Unmarshal(card[0], &cardType); err != nil || !strings.EqualFold(cardType, "vcard") {
+		return nil, malformedResponseError(fmt.Errorf("invalid RDAP jCard kind"))
+	}
+	var properties []json.RawMessage
+	if err := json.Unmarshal(card[1], &properties); err != nil {
+		return nil, malformedResponseError(fmt.Errorf("invalid RDAP jCard properties"))
+	}
+
+	var organizations []string
+	var entityKind string
+	var formattedName string
+	for _, rawProperty := range properties {
+		var property []json.RawMessage
+		if err := json.Unmarshal(rawProperty, &property); err != nil || len(property) == 0 {
+			continue
+		}
+		var name string
+		if err := json.Unmarshal(property[0], &name); err != nil {
+			continue
+		}
+		switch strings.ToLower(name) {
+		case "kind", "fn":
+			if len(property) < 4 {
+				continue
+			}
+			var value string
+			if err := json.Unmarshal(property[3], &value); err != nil {
+				continue
+			}
+			if strings.EqualFold(name, "kind") {
+				entityKind = strings.TrimSpace(value)
+			} else {
+				formattedName = strings.TrimSpace(value)
+			}
+		case "org":
+			if len(property) < 4 {
+				return nil, malformedResponseError(fmt.Errorf("invalid RDAP jCard organization property"))
+			}
+			var single string
+			if err := json.Unmarshal(property[3], &single); err == nil {
+				if single = strings.TrimSpace(single); single != "" {
+					organizations = append(organizations, single)
+				}
+				continue
+			}
+			var multiple []string
+			if err := json.Unmarshal(property[3], &multiple); err != nil {
+				return nil, malformedResponseError(fmt.Errorf("invalid RDAP jCard organization"))
+			}
+			for _, value := range multiple {
+				if value = strings.TrimSpace(value); value != "" {
+					organizations = append(organizations, value)
+				}
+			}
+		}
+	}
+	if len(organizations) == 0 && formattedName != "" &&
+		(strings.EqualFold(entityKind, "org") || strings.EqualFold(entityKind, "organization")) {
+		organizations = append(organizations, formattedName)
+	}
+	return organizations, nil
+}
+
+func normalizeRDAPRedactions(values []rawRDAPRedaction) ([]RDAPRedactionIndicator, error) {
+	redactions := make([]RDAPRedactionIndicator, 0, len(values))
+	for _, value := range values {
+		name := strings.TrimSpace(value.Name.Type)
+		if name == "" {
+			name = strings.TrimSpace(value.Name.Description)
+		}
+		if name == "" {
+			return nil, malformedResponseError(fmt.Errorf("RDAP redaction is missing its name"))
+		}
+		reason := strings.TrimSpace(value.Reason.Type)
+		if reason == "" {
+			reason = strings.TrimSpace(value.Reason.Description)
+		}
+		redactions = append(redactions, RDAPRedactionIndicator{
+			Name:   name,
+			Method: strings.TrimSpace(value.Method),
+			Reason: reason,
+		})
+	}
+	return redactions, nil
+}
+
+func normalizeRDAPStrings(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			normalized = append(normalized, value)
+		}
+	}
+	return normalized
+}
+
+func hasPrivacyStatus(status []string) bool {
+	for _, value := range status {
+		switch strings.ToLower(value) {
+		case "redacted", "private", "obscured":
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), want) {
+			return true
+		}
+	}
+	return false
+}
+
+func deduplicateStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, found := seen[value]; found {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func compareIP(left, right net.IP) int {
+	if left4, right4 := left.To4(), right.To4(); left4 != nil && right4 != nil {
+		return bytes.Compare(left4, right4)
+	}
+	return bytes.Compare(left.To16(), right.To16())
+}
+
+func canonicalIP(ip net.IP) string {
+	if ip4 := ip.To4(); ip4 != nil {
+		return ip4.String()
+	}
+	return ip.String()
+}
+
+func rdapOrigin(value *url.URL) string {
+	if value == nil {
+		return ""
+	}
+	return strings.ToLower(value.Scheme) + "://" + strings.ToLower(value.Host)
+}

--- a/rdap_bootstrap.go
+++ b/rdap_bootstrap.go
@@ -380,9 +380,10 @@ func (resolver *IANARDAPBootstrapResolver) fetch(ctx context.Context, bootstrapU
 		return rdapBootstrapDocument{}, time.Time{}, err
 	}
 
-	expiresAt := time.Now().Add(resolver.fallbackTTL())
+	now := time.Now()
+	expiresAt := now.Add(resolver.fallbackTTL())
 	if expires := response.Header.Get("Expires"); expires != "" {
-		if parsed, err := http.ParseTime(expires); err == nil && parsed.After(time.Now()) {
+		if parsed, err := http.ParseTime(expires); err == nil {
 			expiresAt = parsed
 		}
 	}

--- a/rdap_bootstrap.go
+++ b/rdap_bootstrap.go
@@ -1,0 +1,485 @@
+package pwhois
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// IANARDAPIPv4BootstrapURL is the authoritative IANA IPv4 RDAP bootstrap
+	// registry defined by RFC 9224.
+	IANARDAPIPv4BootstrapURL = "https://data.iana.org/rdap/ipv4.json"
+	// IANARDAPIPv6BootstrapURL is the authoritative IANA IPv6 RDAP bootstrap
+	// registry defined by RFC 9224.
+	IANARDAPIPv6BootstrapURL = "https://data.iana.org/rdap/ipv6.json"
+	// IANARDAPASNBootstrapURL is the authoritative IANA ASN RDAP bootstrap
+	// registry defined by RFC 9224.
+	IANARDAPASNBootstrapURL = "https://data.iana.org/rdap/asn.json"
+
+	// DefaultRDAPBootstrapMaxResponseBytes bounds one IANA bootstrap document.
+	DefaultRDAPBootstrapMaxResponseBytes int64 = 2 * 1024 * 1024
+	// DefaultRDAPBootstrapTTL is used only when the bootstrap HTTP response
+	// supplies no usable Expires header.
+	DefaultRDAPBootstrapTTL = 24 * time.Hour
+)
+
+// RDAPBootstrapResolution identifies the authoritative base URLs for a query
+// and the authorities that may receive a cross-origin RDAP referral. Allowed
+// authorities are derived from the same trusted bootstrap document.
+type RDAPBootstrapResolution struct {
+	BaseURLs           []string
+	AllowedAuthorities []string
+	Publication        time.Time
+}
+
+// RDAPBootstrapResolver resolves IP and ASN queries to authoritative RDAP base
+// URLs without exposing provider-specific bootstrap mechanics to RDAPProvider.
+// Implementations must be safe for concurrent use.
+type RDAPBootstrapResolver interface {
+	ResolveIP(ctx context.Context, ip net.IP) (RDAPBootstrapResolution, error)
+	ResolveASN(ctx context.Context, asn uint32) (RDAPBootstrapResolution, error)
+	CacheIdentity() string
+}
+
+// IANARDAPBootstrapResolver fetches and caches the RFC 9224 IANA bootstrap
+// registries. It honors the HTTP Expires header and does not refetch a fresh
+// registry for every RDAP lookup. Do not copy or mutate a resolver after its
+// first use.
+type IANARDAPBootstrapResolver struct {
+	Client           *http.Client
+	IPv4URL          string
+	IPv6URL          string
+	ASNURL           string
+	MaxResponseBytes int64
+	FallbackTTL      time.Duration
+	// AllowInsecureHTTP exists for controlled local test infrastructure. Do
+	// not enable it for public bootstrap or RDAP traffic.
+	AllowInsecureHTTP bool
+
+	mu       sync.Mutex
+	cache    map[string]rdapBootstrapCacheEntry
+	inflight map[string]chan struct{}
+}
+
+type rdapBootstrapCacheEntry struct {
+	document  rdapBootstrapDocument
+	expiresAt time.Time
+}
+
+type rdapBootstrapDocument struct {
+	Version     string
+	Publication time.Time
+	Services    []rdapBootstrapService
+}
+
+type rdapBootstrapService struct {
+	Entries []string
+	URLs    []string
+}
+
+type rawRDAPBootstrapDocument struct {
+	Version     string       `json:"version"`
+	Publication string       `json:"publication"`
+	Services    [][][]string `json:"services"`
+}
+
+var defaultIANARDAPBootstrapResolver = &IANARDAPBootstrapResolver{}
+
+// CacheIdentity identifies the IANA bootstrap contract in source-aware cache
+// keys.
+func (resolver *IANARDAPBootstrapResolver) CacheIdentity() string {
+	ipv4URL, ipv6URL, asnURL := resolver.configuredURLs()
+	return strings.Join([]string{ipv4URL, ipv6URL, asnURL}, "|")
+}
+
+func (resolver *IANARDAPBootstrapResolver) configuredURLs() (string, string, string) {
+	ipv4URL := resolver.IPv4URL
+	if ipv4URL == "" {
+		ipv4URL = IANARDAPIPv4BootstrapURL
+	}
+	ipv6URL := resolver.IPv6URL
+	if ipv6URL == "" {
+		ipv6URL = IANARDAPIPv6BootstrapURL
+	}
+	asnURL := resolver.ASNURL
+	if asnURL == "" {
+		asnURL = IANARDAPASNBootstrapURL
+	}
+	return ipv4URL, ipv6URL, asnURL
+}
+
+func (resolver *IANARDAPBootstrapResolver) maxResponseBytes() int64 {
+	if resolver.MaxResponseBytes > 0 {
+		return resolver.MaxResponseBytes
+	}
+	return DefaultRDAPBootstrapMaxResponseBytes
+}
+
+func (resolver *IANARDAPBootstrapResolver) fallbackTTL() time.Duration {
+	if resolver.FallbackTTL > 0 {
+		return resolver.FallbackTTL
+	}
+	return DefaultRDAPBootstrapTTL
+}
+
+// ResolveIP performs the RFC 9224 longest-prefix match against the cached
+// IPv4 or IPv6 IANA bootstrap registry.
+func (resolver *IANARDAPBootstrapResolver) ResolveIP(ctx context.Context, ip net.IP) (RDAPBootstrapResolution, error) {
+	if ctx == nil {
+		return RDAPBootstrapResolution{}, invalidInputError("context must not be nil")
+	}
+	if ip == nil {
+		return RDAPBootstrapResolution{}, invalidInputError("IP address is required")
+	}
+
+	ipv4URL, ipv6URL, _ := resolver.configuredURLs()
+	bootstrapURL := ipv6URL
+	wantIPv4 := false
+	if ip.To4() != nil {
+		bootstrapURL = ipv4URL
+		wantIPv4 = true
+	}
+	document, err := resolver.load(ctx, bootstrapURL)
+	if err != nil {
+		return RDAPBootstrapResolution{}, err
+	}
+
+	bestPrefixLength := -1
+	var matchedURLs []string
+	for _, service := range document.Services {
+		serviceMatchedLength := -1
+		for _, entry := range service.Entries {
+			entryIP, prefix, err := net.ParseCIDR(entry)
+			if err != nil || !entryIP.Equal(prefix.IP) || (prefix.IP.To4() != nil) != wantIPv4 {
+				return RDAPBootstrapResolution{}, malformedResponseError(fmt.Errorf("invalid IP bootstrap entry"))
+			}
+			if prefix.Contains(ip) {
+				ones, _ := prefix.Mask.Size()
+				if ones > serviceMatchedLength {
+					serviceMatchedLength = ones
+				}
+			}
+		}
+		if serviceMatchedLength < bestPrefixLength {
+			continue
+		}
+		if serviceMatchedLength == bestPrefixLength && serviceMatchedLength >= 0 {
+			return RDAPBootstrapResolution{}, malformedResponseError(fmt.Errorf("ambiguous IP bootstrap match"))
+		}
+		if serviceMatchedLength >= 0 {
+			bestPrefixLength = serviceMatchedLength
+			matchedURLs = service.URLs
+		}
+	}
+	if bestPrefixLength < 0 {
+		return RDAPBootstrapResolution{}, noRecordsError("IANA RDAP IP bootstrap")
+	}
+
+	return resolver.resolution(document, matchedURLs)
+}
+
+// ResolveASN performs the RFC 9224 inclusive AS-number range match against the
+// cached IANA bootstrap registry.
+func (resolver *IANARDAPBootstrapResolver) ResolveASN(ctx context.Context, asn uint32) (RDAPBootstrapResolution, error) {
+	if ctx == nil {
+		return RDAPBootstrapResolution{}, invalidInputError("context must not be nil")
+	}
+
+	_, _, asnURL := resolver.configuredURLs()
+	document, err := resolver.load(ctx, asnURL)
+	if err != nil {
+		return RDAPBootstrapResolution{}, err
+	}
+
+	var matchedURLs []string
+	found := false
+	for _, service := range document.Services {
+		serviceMatched := false
+		for _, entry := range service.Entries {
+			start, end, err := parseRDAPASNBootstrapRange(entry)
+			if err != nil {
+				return RDAPBootstrapResolution{}, malformedResponseError(err)
+			}
+			if asn >= start && asn <= end {
+				serviceMatched = true
+			}
+		}
+		if !serviceMatched {
+			continue
+		}
+		if found {
+			return RDAPBootstrapResolution{}, malformedResponseError(fmt.Errorf("ambiguous ASN bootstrap match"))
+		}
+		found = true
+		matchedURLs = service.URLs
+	}
+	if !found {
+		return RDAPBootstrapResolution{}, noRecordsError("IANA RDAP ASN bootstrap")
+	}
+
+	return resolver.resolution(document, matchedURLs)
+}
+
+func (resolver *IANARDAPBootstrapResolver) resolution(document rdapBootstrapDocument, matchedURLs []string) (RDAPBootstrapResolution, error) {
+	baseURLs, err := resolver.acceptedURLs(matchedURLs)
+	if err != nil {
+		return RDAPBootstrapResolution{}, err
+	}
+	if len(baseURLs) == 0 {
+		return RDAPBootstrapResolution{}, malformedResponseError(fmt.Errorf("bootstrap match has no secure RDAP URL"))
+	}
+
+	authoritySet := make(map[string]struct{})
+	for _, service := range document.Services {
+		urls, err := resolver.acceptedURLs(service.URLs)
+		if err != nil {
+			return RDAPBootstrapResolution{}, err
+		}
+		for _, value := range urls {
+			parsed, _ := url.Parse(value)
+			authoritySet[strings.ToLower(parsed.Host)] = struct{}{}
+		}
+	}
+	authorities := make([]string, 0, len(authoritySet))
+	for authority := range authoritySet {
+		authorities = append(authorities, authority)
+	}
+	sort.Strings(authorities)
+
+	return RDAPBootstrapResolution{
+		BaseURLs:           baseURLs,
+		AllowedAuthorities: authorities,
+		Publication:        document.Publication,
+	}, nil
+}
+
+func (resolver *IANARDAPBootstrapResolver) acceptedURLs(values []string) ([]string, error) {
+	secure := make([]string, 0, len(values))
+	insecure := make([]string, 0, len(values))
+	for _, value := range values {
+		parsed, err := url.Parse(value)
+		if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" ||
+			parsed.Fragment != "" || !strings.HasSuffix(parsed.Path, "/") {
+			return nil, malformedResponseError(fmt.Errorf("invalid RDAP bootstrap service URL"))
+		}
+		switch strings.ToLower(parsed.Scheme) {
+		case "https":
+			secure = append(secure, parsed.String())
+		case "http":
+			if resolver.AllowInsecureHTTP {
+				insecure = append(insecure, parsed.String())
+			}
+		default:
+			return nil, malformedResponseError(fmt.Errorf("unsupported RDAP bootstrap service URL scheme"))
+		}
+	}
+	return append(secure, insecure...), nil
+}
+
+func (resolver *IANARDAPBootstrapResolver) load(ctx context.Context, bootstrapURL string) (rdapBootstrapDocument, error) {
+	for {
+		resolver.mu.Lock()
+		if resolver.cache != nil {
+			if cached, found := resolver.cache[bootstrapURL]; found && time.Now().Before(cached.expiresAt) {
+				resolver.mu.Unlock()
+				return cached.document, nil
+			}
+		}
+		if waiting, found := resolver.inflight[bootstrapURL]; found {
+			resolver.mu.Unlock()
+			select {
+			case <-waiting:
+				continue
+			case <-ctx.Done():
+				return rdapBootstrapDocument{}, classifyTransportError(ctx.Err())
+			}
+		}
+		if resolver.inflight == nil {
+			resolver.inflight = make(map[string]chan struct{})
+		}
+		waiting := make(chan struct{})
+		resolver.inflight[bootstrapURL] = waiting
+		resolver.mu.Unlock()
+
+		document, expiresAt, err := resolver.fetch(ctx, bootstrapURL)
+
+		resolver.mu.Lock()
+		if err == nil {
+			if resolver.cache == nil {
+				resolver.cache = make(map[string]rdapBootstrapCacheEntry)
+			}
+			resolver.cache[bootstrapURL] = rdapBootstrapCacheEntry{document: document, expiresAt: expiresAt}
+		}
+		delete(resolver.inflight, bootstrapURL)
+		close(waiting)
+		resolver.mu.Unlock()
+		return document, err
+	}
+}
+
+func (resolver *IANARDAPBootstrapResolver) fetch(ctx context.Context, bootstrapURL string) (rdapBootstrapDocument, time.Time, error) {
+	parsedURL, err := url.Parse(bootstrapURL)
+	if err != nil || parsedURL.Host == "" || parsedURL.User != nil ||
+		parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+		return rdapBootstrapDocument{}, time.Time{}, invalidInputError("invalid RDAP bootstrap URL")
+	}
+	if parsedURL.Scheme != "https" && !(resolver.AllowInsecureHTTP && parsedURL.Scheme == "http") {
+		return rdapBootstrapDocument{}, time.Time{}, invalidInputError("RDAP bootstrap URL must use HTTPS")
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	if err != nil {
+		return rdapBootstrapDocument{}, time.Time{}, invalidInputError("invalid RDAP bootstrap request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", AppName)
+
+	response, err := rdapNoRedirectClient(resolver.Client).Do(request)
+	if err != nil {
+		return rdapBootstrapDocument{}, time.Time{}, classifyContextTransportError(ctx, err)
+	}
+	defer response.Body.Close()
+
+	switch response.StatusCode {
+	case http.StatusOK:
+	case http.StatusTooManyRequests:
+		return rdapBootstrapDocument{}, time.Time{}, ErrRateLimited
+	case http.StatusNotFound:
+		return rdapBootstrapDocument{}, time.Time{}, noRecordsError("IANA RDAP bootstrap")
+	default:
+		if response.StatusCode >= 500 {
+			return rdapBootstrapDocument{}, time.Time{}, fmt.Errorf("%w: bootstrap HTTP status %d", ErrConnection, response.StatusCode)
+		}
+		return rdapBootstrapDocument{}, time.Time{}, fmt.Errorf("%w: bootstrap HTTP status %d", ErrProviderRejected, response.StatusCode)
+	}
+	if !isRDAPJSONContentType(response.Header.Get("Content-Type"), "application/json") {
+		return rdapBootstrapDocument{}, time.Time{}, malformedResponseError(fmt.Errorf("unexpected RDAP bootstrap content type"))
+	}
+
+	body, err := readBoundedHTTPBody(response.Body, resolver.maxResponseBytes())
+	if err != nil {
+		if errors.Is(err, ErrResponseTooLarge) {
+			return rdapBootstrapDocument{}, time.Time{}, err
+		}
+		return rdapBootstrapDocument{}, time.Time{}, classifyContextTransportError(ctx, err)
+	}
+	document, err := parseRDAPBootstrapDocument(body)
+	if err != nil {
+		return rdapBootstrapDocument{}, time.Time{}, err
+	}
+
+	expiresAt := time.Now().Add(resolver.fallbackTTL())
+	if expires := response.Header.Get("Expires"); expires != "" {
+		if parsed, err := http.ParseTime(expires); err == nil && parsed.After(time.Now()) {
+			expiresAt = parsed
+		}
+	}
+	return document, expiresAt, nil
+}
+
+func parseRDAPBootstrapDocument(body []byte) (rdapBootstrapDocument, error) {
+	var raw rawRDAPBootstrapDocument
+	if err := decodeSingleJSON(body, &raw); err != nil {
+		return rdapBootstrapDocument{}, malformedResponseError(fmt.Errorf("decode RDAP bootstrap: %w", err))
+	}
+	if raw.Version != "1.0" {
+		return rdapBootstrapDocument{}, malformedResponseError(fmt.Errorf("unsupported RDAP bootstrap version"))
+	}
+	publication, err := time.Parse(time.RFC3339, raw.Publication)
+	if err != nil {
+		return rdapBootstrapDocument{}, malformedResponseError(fmt.Errorf("invalid RDAP bootstrap publication time"))
+	}
+	if len(raw.Services) == 0 {
+		return rdapBootstrapDocument{}, malformedResponseError(fmt.Errorf("RDAP bootstrap contains no services"))
+	}
+
+	document := rdapBootstrapDocument{
+		Version:     raw.Version,
+		Publication: publication,
+		Services:    make([]rdapBootstrapService, 0, len(raw.Services)),
+	}
+	for _, service := range raw.Services {
+		if len(service) != 2 || len(service[0]) == 0 || len(service[1]) == 0 {
+			return rdapBootstrapDocument{}, malformedResponseError(fmt.Errorf("invalid RDAP bootstrap service"))
+		}
+		document.Services = append(document.Services, rdapBootstrapService{
+			Entries: append([]string(nil), service[0]...),
+			URLs:    append([]string(nil), service[1]...),
+		})
+	}
+	return document, nil
+}
+
+func parseRDAPASNBootstrapRange(value string) (uint32, uint32, error) {
+	startText, endText, found := strings.Cut(strings.TrimSpace(value), "-")
+	if !found {
+		return 0, 0, fmt.Errorf("invalid ASN bootstrap range")
+	}
+	start, err := strconv.ParseUint(startText, 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid ASN bootstrap range")
+	}
+	end, err := strconv.ParseUint(endText, 10, 32)
+	if err != nil || start > end {
+		return 0, 0, fmt.Errorf("invalid ASN bootstrap range")
+	}
+	return uint32(start), uint32(end), nil
+}
+
+func rdapNoRedirectClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	cloned := *client
+	cloned.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &cloned
+}
+
+func isRDAPJSONContentType(value, expected string) bool {
+	mediaType, _, err := mime.ParseMediaType(value)
+	return err == nil && strings.EqualFold(mediaType, expected)
+}
+
+func readBoundedHTTPBody(reader io.Reader, limit int64) ([]byte, error) {
+	if limit <= 0 {
+		limit = DefaultMaxResponseBytes
+	}
+	limited := io.LimitReader(reader, limit+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, &ResponseTooLargeError{Limit: limit}
+	}
+	return body, nil
+}
+
+func decodeSingleJSON(body []byte, target any) error {
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}

--- a/rdap_bootstrap_test.go
+++ b/rdap_bootstrap_test.go
@@ -1,0 +1,279 @@
+package pwhois
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestIANARDAPBootstrapResolutionAndCaching(t *testing.T) {
+	var mu sync.Mutex
+	requestCounts := make(map[string]int)
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	writeBootstrap := func(response http.ResponseWriter, request *http.Request, body string) {
+		mu.Lock()
+		requestCounts[request.URL.Path]++
+		mu.Unlock()
+		if request.Header.Get("Accept") != "application/json" || request.Header.Get("User-Agent") != AppName {
+			t.Errorf("bootstrap request headers = %v", request.Header)
+		}
+		response.Header().Set("Content-Type", "application/json; charset=utf-8")
+		response.Header().Set("Expires", time.Now().Add(time.Hour).UTC().Format(http.TimeFormat))
+		_, _ = response.Write([]byte(body))
+	}
+
+	mux.HandleFunc("/ipv4.json", func(response http.ResponseWriter, request *http.Request) {
+		writeBootstrap(response, request, `{
+  "version": "1.0",
+  "publication": "2026-07-29T12:00:00Z",
+  "description": "synthetic IPv4 bootstrap",
+  "services": [
+    [["192.0.0.0/16"], ["https://broad.example.test/rdap/"]],
+    [["192.0.2.0/24"], ["https://specific.example.test/rdap/", "http://specific.example.test/rdap/"]],
+    [["198.51.100.0/24"], ["https://other.example.test/rdap/"]]
+  ]
+}`)
+	})
+	mux.HandleFunc("/asn.json", func(response http.ResponseWriter, request *http.Request) {
+		writeBootstrap(response, request, `{
+  "version": "1.0",
+  "publication": "2026-07-29T12:00:00Z",
+  "services": [
+    [["64496-64510"], ["https://asn.example.test/rdap/"]],
+    [["65536-65551"], ["https://asn32.example.test/rdap/"]]
+  ]
+}`)
+	})
+
+	resolver := &IANARDAPBootstrapResolver{
+		Client:            server.Client(),
+		IPv4URL:           server.URL + "/ipv4.json",
+		IPv6URL:           server.URL + "/ipv6.json",
+		ASNURL:            server.URL + "/asn.json",
+		AllowInsecureHTTP: true,
+	}
+
+	ipResolution, err := resolver.ResolveIP(context.Background(), net.ParseIP("192.0.2.42"))
+	if err != nil {
+		t.Fatalf("ResolveIP: %v", err)
+	}
+	if !reflect.DeepEqual(ipResolution.BaseURLs, []string{"https://specific.example.test/rdap/", "http://specific.example.test/rdap/"}) {
+		t.Fatalf("IP base URLs = %v", ipResolution.BaseURLs)
+	}
+	if !reflect.DeepEqual(ipResolution.AllowedAuthorities, []string{
+		"broad.example.test", "other.example.test", "specific.example.test",
+	}) {
+		t.Fatalf("allowed authorities = %v", ipResolution.AllowedAuthorities)
+	}
+	if ipResolution.Publication.Format(time.RFC3339) != rdapBootstrapPublicationText {
+		t.Fatalf("publication = %v", ipResolution.Publication)
+	}
+
+	if _, err := resolver.ResolveIP(context.Background(), net.ParseIP("192.0.2.99")); err != nil {
+		t.Fatalf("cached ResolveIP: %v", err)
+	}
+	asnResolution, err := resolver.ResolveASN(context.Background(), 64500)
+	if err != nil {
+		t.Fatalf("ResolveASN: %v", err)
+	}
+	if !reflect.DeepEqual(asnResolution.BaseURLs, []string{"https://asn.example.test/rdap/"}) {
+		t.Fatalf("ASN base URLs = %v", asnResolution.BaseURLs)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if requestCounts["/ipv4.json"] != 1 || requestCounts["/asn.json"] != 1 {
+		t.Fatalf("bootstrap request counts = %v, want one request per registry", requestCounts)
+	}
+	if identity := resolver.CacheIdentity(); !strings.Contains(identity, server.URL+"/ipv4.json") ||
+		!strings.Contains(identity, server.URL+"/asn.json") {
+		t.Fatalf("custom cache identity = %q", identity)
+	}
+}
+
+func TestIANARDAPBootstrapNoMatchAndValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		queryIP   string
+		wantError error
+	}{
+		{
+			name: "no match",
+			body: `{
+  "version":"1.0",
+  "publication":"2026-07-29T12:00:00Z",
+  "services":[[["198.51.100.0/24"],["https://rdap.example.test/"]]]
+}`,
+			queryIP:   "192.0.2.42",
+			wantError: ErrNoRecords,
+		},
+		{
+			name: "unsupported version",
+			body: `{
+  "version":"2.0",
+  "publication":"2026-07-29T12:00:00Z",
+  "services":[[["192.0.2.0/24"],["https://rdap.example.test/"]]]
+}`,
+			queryIP:   "192.0.2.42",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name: "ambiguous longest match",
+			body: `{
+  "version":"1.0",
+  "publication":"2026-07-29T12:00:00Z",
+  "services":[
+    [["192.0.2.0/24"],["https://one.example.test/"]],
+    [["192.0.2.0/24"],["https://two.example.test/"]]
+  ]
+}`,
+			queryIP:   "192.0.2.42",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name: "service URL lacks trailing slash",
+			body: `{
+  "version":"1.0",
+  "publication":"2026-07-29T12:00:00Z",
+  "services":[[["192.0.2.0/24"],["https://rdap.example.test/rdap"]]]
+}`,
+			queryIP:   "192.0.2.42",
+			wantError: ErrMalformedResponse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				response.Header().Set("Content-Type", "application/json")
+				_, _ = response.Write([]byte(test.body))
+			}))
+			defer server.Close()
+			resolver := &IANARDAPBootstrapResolver{
+				Client:            server.Client(),
+				IPv4URL:           server.URL,
+				AllowInsecureHTTP: true,
+			}
+
+			_, err := resolver.ResolveIP(context.Background(), net.ParseIP(test.queryIP))
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("ResolveIP error = %v, want %v", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestIANARDAPBootstrapHTTPFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		content   string
+		body      string
+		limit     int64
+		wantError error
+	}{
+		{name: "rate limited", status: http.StatusTooManyRequests, wantError: ErrRateLimited},
+		{name: "server failure", status: http.StatusServiceUnavailable, wantError: ErrConnection},
+		{
+			name:      "wrong content type",
+			status:    http.StatusOK,
+			content:   "text/plain",
+			body:      `{}`,
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "oversized",
+			status:    http.StatusOK,
+			content:   "application/json",
+			body:      strings.Repeat("x", 100),
+			limit:     16,
+			wantError: ErrResponseTooLarge,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				if test.content != "" {
+					response.Header().Set("Content-Type", test.content)
+				}
+				response.WriteHeader(test.status)
+				_, _ = response.Write([]byte(test.body))
+			}))
+			defer server.Close()
+			resolver := &IANARDAPBootstrapResolver{
+				Client:            server.Client(),
+				IPv4URL:           server.URL,
+				MaxResponseBytes:  test.limit,
+				AllowInsecureHTTP: true,
+			}
+
+			_, err := resolver.ResolveIP(context.Background(), net.ParseIP("192.0.2.42"))
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("ResolveIP error = %v, want %v", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestIANARDAPBootstrapCoalescedWaitHonorsContext(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		close(started)
+		<-release
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{
+  "version":"1.0",
+  "publication":"2026-07-29T12:00:00Z",
+  "services":[[["192.0.2.0/24"],["https://rdap.example.test/"]]]
+}`))
+	}))
+	defer server.Close()
+	resolver := &IANARDAPBootstrapResolver{
+		Client:            server.Client(),
+		IPv4URL:           server.URL,
+		AllowInsecureHTTP: true,
+	}
+
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := resolver.ResolveIP(context.Background(), net.ParseIP("192.0.2.42"))
+		firstResult <- err
+	}()
+	<-started
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := resolver.ResolveIP(ctx, net.ParseIP("192.0.2.43"))
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("coalesced wait error = %v, want ErrTimeout", err)
+	}
+	close(release)
+	if err := <-firstResult; err != nil {
+		t.Fatalf("first bootstrap resolution: %v", err)
+	}
+}
+
+func TestParseRDAPASNBootstrapRange(t *testing.T) {
+	start, end, err := parseRDAPASNBootstrapRange("64496-64510")
+	if err != nil || start != 64496 || end != 64510 {
+		t.Fatalf("range = %d-%d, %v", start, end, err)
+	}
+	for _, value := range []string{"", "64510-64496", "AS64500-AS64510", "1-4294967296"} {
+		if _, _, err := parseRDAPASNBootstrapRange(value); err == nil {
+			t.Errorf("range %q unexpectedly accepted", value)
+		}
+	}
+}

--- a/rdap_bootstrap_test.go
+++ b/rdap_bootstrap_test.go
@@ -101,6 +101,36 @@ func TestIANARDAPBootstrapResolutionAndCaching(t *testing.T) {
 	}
 }
 
+func TestIANARDAPBootstrapHonorsExpiredResponse(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requestCount++
+		response.Header().Set("Content-Type", "application/json")
+		response.Header().Set("Expires", time.Now().Add(-time.Hour).UTC().Format(http.TimeFormat))
+		_, _ = response.Write([]byte(`{
+  "version":"1.0",
+  "publication":"2026-07-29T12:00:00Z",
+  "services":[[["192.0.2.0/24"],["https://rdap.example.test/"]]]
+}`))
+	}))
+	defer server.Close()
+
+	resolver := &IANARDAPBootstrapResolver{
+		Client:            server.Client(),
+		IPv4URL:           server.URL,
+		AllowInsecureHTTP: true,
+		FallbackTTL:       time.Hour,
+	}
+	for lookup := 0; lookup < 2; lookup++ {
+		if _, err := resolver.ResolveIP(context.Background(), net.ParseIP("192.0.2.42")); err != nil {
+			t.Fatalf("ResolveIP %d: %v", lookup+1, err)
+		}
+	}
+	if requestCount != 2 {
+		t.Fatalf("expired bootstrap request count = %d, want 2", requestCount)
+	}
+}
+
 func TestIANARDAPBootstrapNoMatchAndValidation(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/rdap_test.go
+++ b/rdap_test.go
@@ -321,6 +321,11 @@ func TestRDAPEntityDeduplicationPreservesDelimiterValues(t *testing.T) {
 			Handle:          "a\x00x",
 			Roles:           []string{"abuse"},
 		},
+		{
+			ObjectClassName: "entity",
+			Handle:          "a",
+			Roles:           []string{"x", "abuse"},
+		},
 	})
 	if err != nil {
 		t.Fatalf("normalize entities: %v", err)

--- a/rdap_test.go
+++ b/rdap_test.go
@@ -337,6 +337,22 @@ func TestRDAPBoundedBootstrapAuthorizedReferral(t *testing.T) {
 	}
 }
 
+func TestRDAPInitialBaseDoesNotRequireReferralAllowlist(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		writeRDAPJSON(response, rdapIPResponse)
+	}))
+	defer server.Close()
+
+	resolver := &staticRDAPBootstrapResolver{}
+	resolver.ipResult = testRDAPResolution(t, server.URL)
+	resolver.ipResult.AllowedAuthorities = nil
+	provider := testRDAPProvider(server, resolver)
+
+	if _, err := provider.LookupIPContext(context.Background(), "192.0.2.42"); err != nil {
+		t.Fatalf("LookupIPContext without referral allowlist: %v", err)
+	}
+}
+
 func TestRDAPReferralFailurePreservesAuthoritativeEndpoint(t *testing.T) {
 	final := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		response.WriteHeader(http.StatusTooManyRequests)

--- a/rdap_test.go
+++ b/rdap_test.go
@@ -251,6 +251,64 @@ func TestRDAPDirectASNLookup(t *testing.T) {
 	}
 }
 
+func TestRDAPNestedEntitiesAndDepthBound(t *testing.T) {
+	nestedEntity := `{
+	  "objectClassName": "entity",
+	  "handle": "PARENT-EXAMPLE",
+	  "entities": [
+	    {
+	      "objectClassName": "entity",
+	      "handle": "ORG-NESTED",
+	      "roles": ["registrant"],
+	      "vcardArray": ["vcard", [
+	        ["version", {}, "text", "4.0"],
+	        ["org", {}, "text", "Nested Example Organization"]
+	      ]]
+	    },
+	    {
+	      "objectClassName": "entity",
+	      "handle": "ABUSE-NESTED",
+	      "roles": ["abuse"],
+	      "status": ["redacted"]
+	    }
+	  ]
+	}`
+	body := strings.Replace(rdapIPResponse, `"entities": [`, `"entities": [`+nestedEntity+`,`, 1)
+	responseURL, _ := url.Parse("https://rdap.example.test/rdap/ip/192.0.2.42")
+	result, err := parseRDAPIPResult("192.0.2.42", rdapHTTPResult{
+		body:     []byte(body),
+		finalURL: responseURL,
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("parse nested entities: %v", err)
+	}
+	if !containsFold(result.RegisteredOrganizations, "Nested Example Organization") {
+		t.Fatalf("nested registered organizations = %v", result.RegisteredOrganizations)
+	}
+	foundNestedAbuse := false
+	for _, contact := range result.AbuseContacts {
+		if contact.Handle == "ABUSE-NESTED" {
+			foundNestedAbuse = true
+		}
+	}
+	if !foundNestedAbuse || !result.Redacted {
+		t.Fatalf("nested abuse/redaction = %+v", result)
+	}
+
+	deepest := `{"objectClassName":"entity"}`
+	for depth := 0; depth <= maxRDAPEntityDepth; depth++ {
+		deepest = `{"objectClassName":"entity","entities":[` + deepest + `]}`
+	}
+	tooDeepBody := strings.Replace(rdapIPResponse, `"entities": [`, `"entities": [`+deepest+`,`, 1)
+	_, err = parseRDAPIPResult("192.0.2.42", rdapHTTPResult{
+		body:     []byte(tooDeepBody),
+		finalURL: responseURL,
+	}, time.Now())
+	if !errors.Is(err, ErrMalformedResponse) {
+		t.Fatalf("deep entity error = %v, want ErrMalformedResponse", err)
+	}
+}
+
 func TestRDAPBoundedBootstrapAuthorizedReferral(t *testing.T) {
 	final := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		writeRDAPJSON(response, rdapIPResponse)
@@ -276,6 +334,35 @@ func TestRDAPBoundedBootstrapAuthorizedReferral(t *testing.T) {
 	}
 	if result.ReferralCount != 1 || result.Endpoint != final.URL {
 		t.Fatalf("referral provenance = %+v", result)
+	}
+}
+
+func TestRDAPReferralFailurePreservesAuthoritativeEndpoint(t *testing.T) {
+	final := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer final.Close()
+	finalURL, _ := url.Parse(final.URL)
+
+	initial := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		http.Redirect(response, request, final.URL+"/rdap/ip/192.0.2.42", http.StatusTemporaryRedirect)
+	}))
+	defer initial.Close()
+	initialURL, _ := url.Parse(initial.URL)
+
+	resolver := &staticRDAPBootstrapResolver{}
+	resolver.ipResult = testRDAPResolution(t, initial.URL)
+	resolver.ipResult.AllowedAuthorities = []string{initialURL.Host, finalURL.Host}
+	provider := testRDAPProvider(initial, resolver)
+	provider.Client = &http.Client{}
+
+	_, err := provider.LookupIPContext(context.Background(), "192.0.2.42")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("lookup error = %v, want ErrRateLimited", err)
+	}
+	var operationError *OperationError
+	if !errors.As(err, &operationError) || operationError.Server != final.URL {
+		t.Fatalf("operation endpoint = %+v, want %q", operationError, final.URL)
 	}
 }
 
@@ -392,6 +479,10 @@ func TestRDAPHTTPFailures(t *testing.T) {
 			if !errors.Is(err, test.wantError) {
 				t.Fatalf("lookup error = %v, want %v", err, test.wantError)
 			}
+			var operationError *OperationError
+			if !errors.As(err, &operationError) || operationError.Server != server.URL {
+				t.Fatalf("operation endpoint = %+v, want %q", operationError, server.URL)
+			}
 		})
 	}
 }
@@ -502,6 +593,32 @@ func TestRDAPRejectsPrivateTargetsByDefault(t *testing.T) {
 	_, err := provider.LookupIPContext(context.Background(), "192.0.2.42")
 	if !errors.Is(err, ErrMalformedResponse) {
 		t.Fatalf("private target error = %v, want ErrMalformedResponse", err)
+	}
+}
+
+func TestRDAPRejectsSpecialUseTargetsAndResolvedAddresses(t *testing.T) {
+	for _, address := range []string{
+		"100.64.0.1",
+		"192.0.0.9",
+		"198.18.0.1",
+		"2001:db8::1",
+		"3fff::1",
+	} {
+		if !unsafeRDAPHostname(address) {
+			t.Errorf("unsafeRDAPHostname(%q) = false", address)
+		}
+	}
+
+	connection, err := publicRDAPDialer().DialContext(
+		context.Background(),
+		"tcp",
+		net.JoinHostPort("localhost", "443"),
+	)
+	if connection != nil {
+		connection.Close()
+	}
+	if !errors.Is(err, ErrMalformedResponse) {
+		t.Fatalf("resolved loopback error = %v, want ErrMalformedResponse", err)
 	}
 }
 

--- a/rdap_test.go
+++ b/rdap_test.go
@@ -1,0 +1,550 @@
+package pwhois
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	rdapBootstrapPublicationText = "2026-07-29T12:00:00Z"
+	rdapIPResponse               = `{
+  "rdapConformance": ["rdap_level_0", "redacted"],
+  "objectClassName": "ip network",
+  "handle": "NET-192-0-2-32-1",
+  "startAddress": "192.0.2.32",
+  "endAddress": "192.0.2.63",
+  "ipVersion": "v4",
+  "name": "EXAMPLE-NET",
+  "type": "DIRECT ALLOCATION",
+  "country": "us",
+  "parentHandle": "NET-192-0-2-0-1",
+  "status": ["active"],
+  "events": [{
+    "eventAction": "registration",
+    "eventDate": "2020-01-02T03:04:05Z",
+    "eventActor": "private-actor@example.test"
+  }],
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "ORG-EXAMPLE",
+      "roles": ["registrant"],
+      "vcardArray": ["vcard", [
+        ["version", {}, "text", "4.0"],
+        ["fn", {}, "text", "Private Person"],
+        ["org", {}, "text", "Example Organization"],
+        ["email", {}, "text", "private@example.test"],
+        ["adr", {}, "text", ["", "", "123 Private Street", "Example", "", "", "ZZ"]]
+      ]]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "ABUSE-EXAMPLE",
+      "roles": ["abuse"],
+      "status": ["redacted"],
+      "vcardArray": ["vcard", [
+        ["version", {}, "text", "4.0"],
+        ["fn", {}, "text", "Private Abuse Contact"],
+        ["email", {}, "text", "abuse@example.test"]
+      ]]
+    }
+  ],
+  "redacted": [{
+    "name": {"description": "Abuse Contact Email"},
+    "postPath": "$.entities[1].vcardArray[1][2][3]",
+    "method": "emptyValue",
+    "reason": {"description": "Server policy"}
+  }]
+}`
+	rdapASNResponse = `{
+  "rdapConformance": ["rdap_level_0"],
+  "objectClassName": "autnum",
+  "handle": "AS64500",
+  "startAutnum": 64500,
+  "endAutnum": 64510,
+  "name": "EXAMPLE-AS-RANGE",
+  "type": "DIRECT ALLOCATION",
+  "country": "ZZ",
+  "status": ["active"],
+  "events": [{
+    "eventAction": "last changed",
+    "eventDate": "2026-07-01T01:02:03Z"
+  }],
+  "entities": [{
+    "objectClassName": "entity",
+    "handle": "ORG-ASN-EXAMPLE",
+    "roles": ["registrant"],
+    "vcardArray": ["vcard", [
+      ["version", {}, "text", "4.0"],
+      ["fn", {}, "text", "ASN Example Organization"],
+      ["kind", {}, "text", "org"]
+    ]]
+  }]
+}`
+)
+
+type staticRDAPBootstrapResolver struct {
+	mu        sync.Mutex
+	identity  string
+	ipResult  RDAPBootstrapResolution
+	asnResult RDAPBootstrapResolution
+	ipError   error
+	asnError  error
+	ipCalls   int
+	asnCalls  int
+}
+
+func (resolver *staticRDAPBootstrapResolver) ResolveIP(context.Context, net.IP) (RDAPBootstrapResolution, error) {
+	resolver.mu.Lock()
+	defer resolver.mu.Unlock()
+	resolver.ipCalls++
+	return resolver.ipResult, resolver.ipError
+}
+
+func (resolver *staticRDAPBootstrapResolver) ResolveASN(context.Context, uint32) (RDAPBootstrapResolution, error) {
+	resolver.mu.Lock()
+	defer resolver.mu.Unlock()
+	resolver.asnCalls++
+	return resolver.asnResult, resolver.asnError
+}
+
+func (resolver *staticRDAPBootstrapResolver) CacheIdentity() string {
+	if resolver.identity != "" {
+		return resolver.identity
+	}
+	return "test-rdap-bootstrap"
+}
+
+func testRDAPResolution(t *testing.T, serverURL string) RDAPBootstrapResolution {
+	t.Helper()
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	publication, _ := time.Parse(time.RFC3339, rdapBootstrapPublicationText)
+	return RDAPBootstrapResolution{
+		BaseURLs:           []string{serverURL + "/rdap/"},
+		AllowedAuthorities: []string{parsed.Host},
+		Publication:        publication,
+	}
+}
+
+func testRDAPProvider(server *httptest.Server, resolver *staticRDAPBootstrapResolver) RDAPProvider {
+	return RDAPProvider{
+		Client:                     server.Client(),
+		Bootstrap:                  resolver,
+		Timeout:                    time.Second,
+		MaxResponseBytes:           DefaultMaxResponseBytes,
+		MaxReferrals:               DefaultRDAPMaxReferrals,
+		AllowInsecureHTTP:          true,
+		AllowPrivateNetworkTargets: true,
+	}
+}
+
+func writeRDAPJSON(response http.ResponseWriter, body string) {
+	response.Header().Set("Content-Type", "application/rdap+json; charset=utf-8")
+	response.WriteHeader(http.StatusOK)
+	_, _ = response.Write([]byte(body))
+}
+
+func TestRDAPDirectIPLookupPrivacyAndProvenance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/rdap/ip/192.0.2.42" {
+			t.Errorf("request path = %q", request.URL.Path)
+		}
+		if request.Header.Get("Accept") != "application/rdap+json" || request.Header.Get("User-Agent") != AppName {
+			t.Errorf("request headers = %v", request.Header)
+		}
+		writeRDAPJSON(response, rdapIPResponse)
+	}))
+	defer server.Close()
+
+	resolver := &staticRDAPBootstrapResolver{}
+	resolver.ipResult = testRDAPResolution(t, server.URL)
+	provider := testRDAPProvider(server, resolver)
+	started := time.Now().UTC()
+
+	result, err := provider.LookupIPContext(context.Background(), " 192.0.2.42 ")
+	if err != nil {
+		t.Fatalf("LookupIPContext: %v", err)
+	}
+	finished := time.Now().UTC()
+	if result.Query != "192.0.2.42" || result.StartAddress != "192.0.2.32" ||
+		result.EndAddress != "192.0.2.63" || result.IPVersion != "v4" {
+		t.Fatalf("IP range = %+v", result)
+	}
+	if result.Handle != "NET-192-0-2-32-1" || result.Name != "EXAMPLE-NET" ||
+		result.CountryCode != "US" || result.ParentHandle != "NET-192-0-2-0-1" {
+		t.Fatalf("registration fields = %+v", result)
+	}
+	if len(result.RegisteredOrganizations) != 1 || result.RegisteredOrganizations[0] != "Example Organization" {
+		t.Fatalf("registered organizations = %v", result.RegisteredOrganizations)
+	}
+	if len(result.AbuseContacts) != 1 || result.AbuseContacts[0].Handle != "ABUSE-EXAMPLE" {
+		t.Fatalf("abuse contacts = %+v", result.AbuseContacts)
+	}
+	if !result.Redacted || len(result.Redactions) != 1 ||
+		result.Redactions[0].Name != "Abuse Contact Email" {
+		t.Fatalf("redaction = %+v", result)
+	}
+	if result.Source != RDAPSource || result.Registry != "127.0.0.1" ||
+		result.Endpoint != server.URL || result.ReferralCount != 0 {
+		t.Fatalf("provenance = %+v", result)
+	}
+	if result.BootstrapPublication.Format(time.RFC3339) != rdapBootstrapPublicationText ||
+		result.FetchedAt.Before(started) || result.FetchedAt.After(finished) {
+		t.Fatalf("timestamps = %+v", result)
+	}
+
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	for _, privateValue := range []string{
+		"Private Person", "private@example.test", "123 Private Street",
+		"Private Abuse Contact", "abuse@example.test", "private-actor@example.test",
+		"$.entities",
+	} {
+		if strings.Contains(string(encoded), privateValue) {
+			t.Errorf("normalized result retained private value %q", privateValue)
+		}
+	}
+}
+
+func TestRDAPDirectASNLookup(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/rdap/autnum/64505" {
+			t.Errorf("request path = %q", request.URL.Path)
+		}
+		writeRDAPJSON(response, rdapASNResponse)
+	}))
+	defer server.Close()
+
+	resolver := &staticRDAPBootstrapResolver{}
+	resolver.asnResult = testRDAPResolution(t, server.URL)
+	provider := testRDAPProvider(server, resolver)
+
+	result, err := provider.LookupASNContext(context.Background(), "AS64505")
+	if err != nil {
+		t.Fatalf("LookupASNContext: %v", err)
+	}
+	if result.Query != 64505 || result.StartAutnum != 64500 || result.EndAutnum != 64510 ||
+		result.Handle != "AS64500" || result.Name != "EXAMPLE-AS-RANGE" {
+		t.Fatalf("ASN result = %+v", result)
+	}
+	if !reflect.DeepEqual(result.RegisteredOrganizations, []string{"ASN Example Organization"}) {
+		t.Fatalf("ASN registered organizations = %v", result.RegisteredOrganizations)
+	}
+	if result.Source != RDAPSource || result.Registry != "127.0.0.1" {
+		t.Fatalf("ASN provenance = %+v", result)
+	}
+}
+
+func TestRDAPBoundedBootstrapAuthorizedReferral(t *testing.T) {
+	final := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		writeRDAPJSON(response, rdapIPResponse)
+	}))
+	defer final.Close()
+	finalURL, _ := url.Parse(final.URL)
+
+	initial := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		http.Redirect(response, request, final.URL+"/rdap/ip/192.0.2.42", http.StatusMovedPermanently)
+	}))
+	defer initial.Close()
+	initialURL, _ := url.Parse(initial.URL)
+
+	resolver := &staticRDAPBootstrapResolver{}
+	resolver.ipResult = testRDAPResolution(t, initial.URL)
+	resolver.ipResult.AllowedAuthorities = []string{initialURL.Host, finalURL.Host}
+	provider := testRDAPProvider(initial, resolver)
+	provider.Client = &http.Client{}
+
+	result, err := provider.LookupIPContext(context.Background(), "192.0.2.42")
+	if err != nil {
+		t.Fatalf("LookupIPContext referral: %v", err)
+	}
+	if result.ReferralCount != 1 || result.Endpoint != final.URL {
+		t.Fatalf("referral provenance = %+v", result)
+	}
+}
+
+func TestRDAPUnsafeReferrals(t *testing.T) {
+	tests := []struct {
+		name       string
+		location   func(string) string
+		allowFinal bool
+	}{
+		{
+			name:       "cross-origin authority absent from bootstrap",
+			location:   func(finalURL string) string { return finalURL + "/rdap/ip/192.0.2.42" },
+			allowFinal: false,
+		},
+		{
+			name:       "referral changes resource",
+			location:   func(finalURL string) string { return finalURL + "/rdap/ip/198.51.100.1" },
+			allowFinal: true,
+		},
+		{
+			name:       "referral loop",
+			location:   func(string) string { return "/rdap/ip/192.0.2.42" },
+			allowFinal: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			final := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				writeRDAPJSON(response, rdapIPResponse)
+			}))
+			defer final.Close()
+			finalURL, _ := url.Parse(final.URL)
+
+			initial := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				http.Redirect(response, request, test.location(final.URL), http.StatusFound)
+			}))
+			defer initial.Close()
+			initialURL, _ := url.Parse(initial.URL)
+
+			resolver := &staticRDAPBootstrapResolver{}
+			resolver.ipResult = testRDAPResolution(t, initial.URL)
+			resolver.ipResult.AllowedAuthorities = []string{initialURL.Host}
+			if test.allowFinal {
+				resolver.ipResult.AllowedAuthorities = append(resolver.ipResult.AllowedAuthorities, finalURL.Host)
+			}
+			provider := testRDAPProvider(initial, resolver)
+			provider.Client = &http.Client{}
+
+			_, err := provider.LookupIPContext(context.Background(), "192.0.2.42")
+			if !errors.Is(err, ErrMalformedResponse) {
+				t.Fatalf("lookup error = %v, want ErrMalformedResponse", err)
+			}
+		})
+	}
+}
+
+func TestRDAPHTTPFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		content   string
+		body      string
+		limit     int64
+		wantError error
+	}{
+		{name: "not found", status: http.StatusNotFound, wantError: ErrNoRecords},
+		{name: "rate limited", status: http.StatusTooManyRequests, wantError: ErrRateLimited},
+		{name: "rejected", status: http.StatusForbidden, wantError: ErrProviderRejected},
+		{name: "server failure", status: http.StatusServiceUnavailable, wantError: ErrConnection},
+		{
+			name:      "wrong content type",
+			status:    http.StatusOK,
+			content:   "text/html",
+			body:      rdapIPResponse,
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "malformed JSON",
+			status:    http.StatusOK,
+			content:   "application/rdap+json",
+			body:      "{",
+			wantError: ErrMalformedResponse,
+		},
+		{
+			name:      "oversized body",
+			status:    http.StatusOK,
+			content:   "application/rdap+json",
+			body:      rdapIPResponse,
+			limit:     32,
+			wantError: ErrResponseTooLarge,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				if test.content != "" {
+					response.Header().Set("Content-Type", test.content)
+				}
+				response.WriteHeader(test.status)
+				_, _ = response.Write([]byte(test.body))
+			}))
+			defer server.Close()
+
+			resolver := &staticRDAPBootstrapResolver{}
+			resolver.ipResult = testRDAPResolution(t, server.URL)
+			provider := testRDAPProvider(server, resolver)
+			if test.limit > 0 {
+				provider.MaxResponseBytes = test.limit
+			}
+
+			_, err := provider.LookupIPContext(context.Background(), "192.0.2.42")
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("lookup error = %v, want %v", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestRDAPResponseValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "range omits query",
+			body: strings.Replace(rdapIPResponse, `"startAddress": "192.0.2.32"`, `"startAddress": "198.51.100.1"`, 1),
+		},
+		{
+			name: "wrong object class",
+			body: strings.Replace(rdapIPResponse, `"objectClassName": "ip network"`, `"objectClassName": "autnum"`, 1),
+		},
+		{
+			name: "missing conformance",
+			body: strings.Replace(rdapIPResponse, `"rdapConformance": ["rdap_level_0", "redacted"],`, "", 1),
+		},
+		{
+			name: "invalid event date",
+			body: strings.Replace(rdapIPResponse, `"2020-01-02T03:04:05Z"`, `"yesterday"`, 1),
+		},
+		{
+			name: "trailing JSON",
+			body: rdapIPResponse + `{}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			responseURL, _ := url.Parse("https://rdap.example.test/rdap/ip/192.0.2.42")
+			_, err := parseRDAPIPResult("192.0.2.42", rdapHTTPResult{
+				body:     []byte(test.body),
+				finalURL: responseURL,
+			}, time.Now())
+			if !errors.Is(err, ErrMalformedResponse) {
+				t.Fatalf("parse error = %v, want ErrMalformedResponse", err)
+			}
+		})
+	}
+}
+
+func TestRDAPInputAndCacheKeys(t *testing.T) {
+	resolver := &staticRDAPBootstrapResolver{identity: "https://bootstrap.example.test/rdap"}
+	provider := RDAPProvider{Bootstrap: resolver}
+	for _, value := range []string{"", "not-an-ip"} {
+		if _, err := provider.LookupIPContext(context.Background(), value); !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("IP %q error = %v, want ErrInvalidInput", value, err)
+		}
+	}
+	for _, value := range []string{"", "not-an-asn", "AS4294967296"} {
+		if _, err := provider.LookupASNContext(context.Background(), value); !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("ASN %q error = %v, want ErrInvalidInput", value, err)
+		}
+	}
+	if _, err := provider.LookupIPContext(nil, "192.0.2.42"); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("nil IP context error = %v", err)
+	}
+	if _, err := provider.LookupASNContext(nil, "64500"); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("nil ASN context error = %v", err)
+	}
+
+	ipSpec, err := provider.IPCacheKeySpec("192.0.2.42")
+	if err != nil {
+		t.Fatalf("IPCacheKeySpec: %v", err)
+	}
+	asnSpec, err := provider.ASNCacheKeySpec("AS64500")
+	if err != nil {
+		t.Fatalf("ASNCacheKeySpec: %v", err)
+	}
+	if ipSpec.Source != RDAPSource || ipSpec.Endpoint != resolver.identity ||
+		ipSpec.Options["object"] != "ip" || ipSpec.NormalizedQuery != "192.0.2.42" {
+		t.Fatalf("IP cache spec = %+v", ipSpec)
+	}
+	if asnSpec.Options["object"] != "autnum" || asnSpec.NormalizedQuery != "64500" {
+		t.Fatalf("ASN cache spec = %+v", asnSpec)
+	}
+	ipKey, _ := CanonicalCacheKey(ipSpec)
+	asnKey, _ := CanonicalCacheKey(asnSpec)
+	if ipKey == asnKey {
+		t.Fatalf("IP and ASN keys must differ: %q", ipKey)
+	}
+
+	client := &http.Client{}
+	constructed := NewRDAPProvider(client)
+	bootstrap, ok := constructed.Bootstrap.(*IANARDAPBootstrapResolver)
+	if !ok || constructed.Client != client || bootstrap.Client != client {
+		t.Fatalf("NewRDAPProvider did not share the supplied HTTP client")
+	}
+}
+
+func TestRDAPRejectsPrivateTargetsByDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		writeRDAPJSON(response, rdapIPResponse)
+	}))
+	defer server.Close()
+	resolver := &staticRDAPBootstrapResolver{}
+	resolver.ipResult = testRDAPResolution(t, server.URL)
+	provider := RDAPProvider{
+		Client:            server.Client(),
+		Bootstrap:         resolver,
+		AllowInsecureHTTP: true,
+	}
+
+	_, err := provider.LookupIPContext(context.Background(), "192.0.2.42")
+	if !errors.Is(err, ErrMalformedResponse) {
+		t.Fatalf("private target error = %v, want ErrMalformedResponse", err)
+	}
+}
+
+func TestRDAPRequiresHTTPSByDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		writeRDAPJSON(response, rdapIPResponse)
+	}))
+	defer server.Close()
+	resolver := &staticRDAPBootstrapResolver{}
+	resolver.ipResult = testRDAPResolution(t, server.URL)
+	provider := RDAPProvider{
+		Client:                     server.Client(),
+		Bootstrap:                  resolver,
+		AllowPrivateNetworkTargets: true,
+	}
+
+	_, err := provider.LookupIPContext(context.Background(), "192.0.2.42")
+	if !errors.Is(err, ErrMalformedResponse) {
+		t.Fatalf("insecure target error = %v, want ErrMalformedResponse", err)
+	}
+}
+
+func TestRDAPContextDeadline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+	resolver := &staticRDAPBootstrapResolver{}
+	resolver.ipResult = testRDAPResolution(t, server.URL)
+	provider := testRDAPProvider(server, resolver)
+	provider.Timeout = 10 * time.Millisecond
+
+	_, err := provider.LookupIPContext(context.Background(), "192.0.2.42")
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("deadline error = %v, want ErrTimeout", err)
+	}
+}
+
+func TestRDAPBootstrapErrorsPropagate(t *testing.T) {
+	resolver := &staticRDAPBootstrapResolver{ipError: fmt.Errorf("bootstrap: %w", ErrRateLimited)}
+	provider := RDAPProvider{Bootstrap: resolver}
+	_, err := provider.LookupIPContext(context.Background(), "192.0.2.42")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("bootstrap error = %v, want ErrRateLimited", err)
+	}
+}

--- a/rdap_test.go
+++ b/rdap_test.go
@@ -309,6 +309,27 @@ func TestRDAPNestedEntitiesAndDepthBound(t *testing.T) {
 	}
 }
 
+func TestRDAPEntityDeduplicationPreservesDelimiterValues(t *testing.T) {
+	_, contacts, _, err := normalizeRDAPEntities([]rawRDAPEntity{
+		{
+			ObjectClassName: "entity",
+			Handle:          "a",
+			Roles:           []string{"x", "abuse"},
+		},
+		{
+			ObjectClassName: "entity",
+			Handle:          "a\x00x",
+			Roles:           []string{"abuse"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("normalize entities: %v", err)
+	}
+	if len(contacts) != 2 {
+		t.Fatalf("abuse contacts = %+v, want both delimiter-containing references", contacts)
+	}
+}
+
 func TestRDAPBoundedBootstrapAuthorizedReferral(t *testing.T) {
 	final := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		writeRDAPJSON(response, rdapIPResponse)


### PR DESCRIPTION
## Summary

- add standards-based RDAP IP and ASN providers backed by IANA bootstrap data
- enforce bounded, referral-aware HTTPS lookups with stable typed errors and privacy-minimized results
- add deterministic local fixtures for bootstrap, referrals, validation, limits, cancellation, and cache identity
- document the public contracts, security boundaries, cache guidance, and consumer workflow

## Validation

- `go test ./...`
- `go test -run RDAP -count=50 ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go mod tidy`
- `go mod verify`
- `git diff --check`

Closes #54